### PR TITLE
feat(dataprocessing-mcp-server): AWS Glue Interactive Sessions and Workflows mcp tools

### DIFF
--- a/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/handlers/glue/glue_interactive_sessions_handler.py
+++ b/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/handlers/glue/glue_interactive_sessions_handler.py
@@ -1,0 +1,749 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GlueInteractiveSessionsHandler for Data Processing MCP Server."""
+
+import os
+from awslabs.dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.dataprocessing_mcp_server.utils.logging_helper import (
+    LogLevel,
+    log_with_request_id,
+)
+from awslabs.dataprocessing_mcp_server.models.glue_models import (
+    CreateSessionResponse,
+    DeleteSessionResponse,
+    GetSessionResponse,
+    ListSessionsResponse,
+    StopSessionResponse,
+    RunStatementResponse,
+    CancelStatementResponse,
+    GetStatementResponse,
+    ListStatementsResponse,
+)
+
+from mcp.server.fastmcp import Context
+from mcp.types import TextContent
+from pydantic import Field, BaseModel
+from typing import Dict, List, Optional, Tuple, Union, cast, Any
+from botocore.exceptions import ClientError
+
+
+class GlueInteractiveSessionsHandler:
+    """Handler for Amazon Glue Interactive Sessions operations."""
+
+    def __init__(
+        self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False
+    ):
+        """Initialize the Glue Interactive Sessions handler.
+
+        Args:
+            mcp: The MCP server instance
+            allow_write: Whether to enable write access (default: False)
+            allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+        """
+        self.mcp = mcp
+        self.allow_write = allow_write
+        self.allow_sensitive_data_access = allow_sensitive_data_access
+        self.glue_client = AwsHelper.create_boto3_client("glue")
+
+        # Register tools
+        self.mcp.tool(name="manage_aws_glue_sessions")(self.manage_aws_glue_sessions)
+        self.mcp.tool(name="manage_aws_glue_statements")(
+            self.manage_aws_glue_statements
+        )
+
+    async def manage_aws_glue_sessions(
+        self,
+        ctx: Context,
+        operation: str = Field(
+            ...,
+            description='Operation to perform: create-session, delete-session, get-session, list-sessions, stop-session. Choose "get-session" or "list-sessions" for read-only operations when write access is disabled.',
+        ),
+        session_id: Optional[str] = Field(
+            None,
+            description="ID of the session (required for delete-session, get-session, and stop-session operations).",
+        ),
+        description: Optional[str] = Field(
+            None,
+            description="Description of the session (optional for create-session operation).",
+        ),
+        role: Optional[str] = Field(
+            None,
+            description="IAM Role ARN (required for create-session operation).",
+        ),
+        command: Optional[Dict[str, str]] = Field(
+            None,
+            description="Session command with Name (e.g., 'glueetl', 'gluestreaming') and optional PythonVersion (required for create-session operation).",
+        ),
+        timeout: Optional[int] = Field(
+            None,
+            description="Number of minutes before session times out (optional for create-session operation).",
+        ),
+        idle_timeout: Optional[int] = Field(
+            None,
+            description="Number of minutes when idle before session times out (optional for create-session operation).",
+        ),
+        default_arguments: Optional[Dict[str, str]] = Field(
+            None,
+            description="Map of key-value pairs for session arguments (optional for create-session operation).",
+        ),
+        connections: Optional[Dict[str, List[str]]] = Field(
+            None,
+            description="Connections to use for the session (optional for create-session operation).",
+        ),
+        max_capacity: Optional[float] = Field(
+            None,
+            description="Number of Glue data processing units (DPUs) to allocate (optional for create-session operation).",
+        ),
+        number_of_workers: Optional[int] = Field(
+            None,
+            description="Number of workers to use for the session (optional for create-session operation).",
+        ),
+        worker_type: Optional[str] = Field(
+            None,
+            description="Type of predefined worker (G.1X, G.2X, G.4X, G.8X, Z.2X) (optional for create-session operation).",
+        ),
+        security_configuration: Optional[str] = Field(
+            None,
+            description="Name of the SecurityConfiguration structure (optional for create-session operation).",
+        ),
+        glue_version: Optional[str] = Field(
+            None,
+            description="Glue version to use (must be greater than 2.0) (optional for create-session operation).",
+        ),
+        tags: Optional[Dict[str, str]] = Field(
+            None,
+            description="Map of key-value pairs (tags) for the session (optional for create-session operation).",
+        ),
+        request_origin: Optional[str] = Field(
+            None,
+            description="Origin of the request (optional for all operations).",
+        ),
+        max_results: Optional[int] = Field(
+            None,
+            description="Maximum number of results to return for list-sessions operation.",
+        ),
+        next_token: Optional[str] = Field(
+            None,
+            description="Pagination token for list-sessions operation.",
+        ),
+    ) -> Union[
+        CreateSessionResponse,
+        DeleteSessionResponse,
+        GetSessionResponse,
+        ListSessionsResponse,
+        StopSessionResponse,
+    ]:
+        """Manage AWS Glue Interactive Sessions for running Spark and Ray workloads.
+
+        This tool provides operations for creating and managing Glue Interactive Sessions, which
+        enable interactive development and execution of Spark ETL scripts and Ray applications.
+        Interactive sessions provide a responsive environment for data exploration, debugging,
+        and iterative development.
+
+        ## Requirements
+        - The server must be run with the `--allow-write` flag for create-session, delete-session, and stop-session operations
+        - Appropriate AWS permissions for Glue Interactive Session operations
+
+        ## Operations
+        - **create-session**: Create a new interactive session with specified configuration
+        - **delete-session**: Delete an existing interactive session
+        - **get-session**: Retrieve detailed information about a specific session
+        - **list-sessions**: List all interactive sessions with optional filtering
+        - **stop-session**: Stop a running interactive session
+
+        ## Example
+        ```python
+        # Create a new Spark ETL session
+        {
+          "operation": "create-session",
+          "session_id": "my-spark-session",
+          "role": "arn:aws:iam::123456789012:role/GlueInteractiveSessionRole",
+          "command": {
+            "Name": "glueetl",
+            "PythonVersion": "3"
+          },
+          "glue_version": "3.0"
+        }
+        ```
+
+        Args:
+            ctx: MCP context
+            operation: Operation to perform
+            session_id: ID of the session
+            description: Description of the session
+            role: IAM Role ARN
+            command: Session command configuration
+            timeout: Number of minutes before session times out
+            idle_timeout: Number of minutes when idle before session times out
+            default_arguments: Map of key-value pairs for session arguments
+            connections: Connections to use for the session
+            max_capacity: Number of Glue DPUs to allocate
+            number_of_workers: Number of workers to use
+            worker_type: Type of predefined worker
+            security_configuration: Name of the SecurityConfiguration structure
+            glue_version: Glue version to use
+            tags: Map of key-value pairs (tags) for the session
+            request_origin: Origin of the request
+            max_results: Maximum number of results to return
+            next_token: Pagination token
+
+        Returns:
+            Union of response types specific to the operation performed
+        """
+        try:
+            if not self.allow_write and operation not in [
+                "get-session",
+                "list-sessions",
+            ]:
+                error_message = (
+                    f"Operation {operation} is not allowed without write access"
+                )
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+
+                if operation == "create-session":
+                    return CreateSessionResponse(
+                        isError=True,
+                        content=[TextContent(type="text", text=error_message)],
+                        session_id="",
+                        session=None,
+                    )
+                elif operation == "delete-session":
+                    return DeleteSessionResponse(
+                        isError=True,
+                        content=[TextContent(type="text", text=error_message)],
+                        session_id="",
+                    )
+                elif operation == "stop-session":
+                    return StopSessionResponse(
+                        isError=True,
+                        content=[TextContent(type="text", text=error_message)],
+                        session_id="",
+                    )
+
+            if operation == "create-session":
+                if not role or not command:
+                    raise ValueError(
+                        "role and command are required for create-session operation"
+                    )
+
+                # Prepare create session parameters
+                create_params = {
+                    "Id": session_id,
+                    "Role": role,
+                    "Command": command,
+                }
+
+                # Add optional parameters if provided
+                if description:
+                    create_params["Description"] = description
+                if timeout:
+                    create_params["Timeout"] = timeout
+                if idle_timeout:
+                    create_params["IdleTimeout"] = idle_timeout
+                if default_arguments:
+                    create_params["DefaultArguments"] = default_arguments
+                if connections:
+                    create_params["Connections"] = connections
+                if max_capacity:
+                    create_params["MaxCapacity"] = max_capacity
+                if number_of_workers:
+                    create_params["NumberOfWorkers"] = number_of_workers
+                if worker_type:
+                    create_params["WorkerType"] = worker_type
+                if security_configuration:
+                    create_params["SecurityConfiguration"] = security_configuration
+                if glue_version:
+                    create_params["GlueVersion"] = glue_version
+
+                # Add MCP management tags
+                resource_tags = AwsHelper.prepare_resource_tags("GlueSession")
+
+                # Merge user-provided tags with MCP tags
+                if tags:
+                    merged_tags = tags.copy()
+                    merged_tags.update(resource_tags)
+                    create_params["Tags"] = merged_tags
+                else:
+                    create_params["Tags"] = resource_tags
+
+                if request_origin:
+                    create_params["RequestOrigin"] = request_origin
+
+                # Create the session
+                response = self.glue_client.create_session(**create_params)
+
+                return CreateSessionResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully created session {response.get('Session', {}).get('Id', '')}",
+                        )
+                    ],
+                    session_id=response.get("Session", {}).get("Id", ""),
+                    session=response.get("Session", {}),
+                )
+
+            elif operation == "delete-session":
+                if session_id is None:
+                    raise ValueError(
+                        "session_id is required for delete-session operation"
+                    )
+
+                # First check if the session is managed by MCP
+                try:
+                    # Get the session to check if it's managed by MCP
+                    get_params = {"Id": session_id}
+                    if request_origin:
+                        get_params["RequestOrigin"] = request_origin
+
+                    response = self.glue_client.get_session(**get_params)
+                    session = response.get("Session", {})
+                    tags = session.get("Tags", {})
+
+                    # Construct the ARN for the session
+                    region = AwsHelper.get_aws_region() or "us-east-1"
+                    account_id = AwsHelper.get_aws_account_id()
+                    session_arn = (
+                        f"arn:aws:glue:{region}:{account_id}:session/{session_id}"
+                    )
+
+                    # Check if the session is managed by MCP
+                    if not AwsHelper.is_resource_mcp_managed(
+                        self.glue_client, session_arn, {}
+                    ):
+                        error_message = f"Cannot delete session {session_id} - it is not managed by the MCP server (missing required tags)"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return DeleteSessionResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            session_id=session_id,
+                            operation="delete-session",
+                        )
+                except ClientError as e:
+                    if e.response["Error"]["Code"] == "EntityNotFoundException":
+                        error_message = f"Session {session_id} not found"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return DeleteSessionResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            session_id=session_id,
+                            operation="delete-session",
+                        )
+                    else:
+                        raise e
+
+                # Prepare delete session parameters
+                delete_params = {"Id": session_id}
+                if request_origin:
+                    delete_params["RequestOrigin"] = request_origin
+
+                # Delete the session
+                response = self.glue_client.delete_session(**delete_params)
+
+                return DeleteSessionResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully deleted session {session_id}",
+                        )
+                    ],
+                    session_id=session_id,
+                    operation="delete-session",
+                )
+
+            elif operation == "get-session":
+                if session_id is None:
+                    raise ValueError("session_id is required for get-session operation")
+
+                # Prepare get session parameters
+                get_params = {"Id": session_id}
+                if request_origin:
+                    get_params["RequestOrigin"] = request_origin
+
+                # Get the session
+                response = self.glue_client.get_session(**get_params)
+
+                return GetSessionResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully retrieved session {session_id}",
+                        )
+                    ],
+                    session_id=session_id,
+                    session=response.get("Session", {}),
+                )
+
+            elif operation == "list-sessions":
+                # Prepare list sessions parameters
+                params: Dict[str, Any] = {}
+                if max_results is not None:
+                    params["MaxResults"] = str(max_results)
+                if next_token is not None:
+                    params["NextToken"] = next_token
+                if tags:
+                    params["Tags"] = tags
+                if request_origin:
+                    params["RequestOrigin"] = request_origin
+
+                # List sessions
+                response = self.glue_client.list_sessions(**params)
+
+                return ListSessionsResponse(
+                    isError=False,
+                    content=[
+                        TextContent(type="text", text="Successfully retrieved sessions")
+                    ],
+                    sessions=response.get("Sessions", []),
+                    ids=response.get("Ids", []),
+                    next_token=response.get("NextToken"),
+                    count=len(response.get("Sessions", [])),
+                )
+
+            elif operation == "stop-session":
+                if session_id is None:
+                    raise ValueError(
+                        "session_id is required for stop-session operation"
+                    )
+
+                # First check if the session is managed by MCP
+                try:
+                    # Get the session to check if it's managed by MCP
+                    get_params = {"Id": session_id}
+                    if request_origin:
+                        get_params["RequestOrigin"] = request_origin
+
+                    response = self.glue_client.get_session(**get_params)
+                    session = response.get("Session", {})
+                    tags = session.get("Tags", {})
+
+                    # Construct the ARN for the session
+                    region = AwsHelper.get_aws_region() or "us-east-1"
+                    account_id = AwsHelper.get_aws_account_id()
+                    session_arn = (
+                        f"arn:aws:glue:{region}:{account_id}:session/{session_id}"
+                    )
+
+                    # Check if the session is managed by MCP
+                    if not AwsHelper.is_resource_mcp_managed(
+                        self.glue_client, session_arn, {}
+                    ):
+                        error_message = f"Cannot stop session {session_id} - it is not managed by the MCP server (missing required tags)"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return StopSessionResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            session_id=session_id,
+                        )
+                except ClientError as e:
+                    if e.response["Error"]["Code"] == "EntityNotFoundException":
+                        error_message = f"Session {session_id} not found"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return StopSessionResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            session_id=session_id,
+                        )
+                    else:
+                        raise e
+
+                # Prepare stop session parameters
+                stop_params = {"Id": session_id}
+                if request_origin:
+                    stop_params["RequestOrigin"] = request_origin
+
+                # Stop the session
+                response = self.glue_client.stop_session(**stop_params)
+
+                return StopSessionResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully stopped session {session_id}",
+                        )
+                    ],
+                    session_id=session_id,
+                )
+
+            else:
+                error_message = f"Invalid operation: {operation}. Must be one of: create-session, delete-session, get-session, list-sessions, stop-session"
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                return GetSessionResponse(
+                    isError=True,
+                    content=[TextContent(type="text", text=error_message)],
+                    session_id=session_id or "",
+                    session={},
+                )
+
+        except ValueError as e:
+            log_with_request_id(
+                ctx, LogLevel.ERROR, f"Parameter validation error: {str(e)}"
+            )
+            raise
+        except Exception as e:
+            error_message = f"Error in manage_aws_glue_sessions: {str(e)}"
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+            return GetSessionResponse(
+                isError=True,
+                content=[TextContent(type="text", text=error_message)],
+                session_id=session_id or "",
+                session={},
+            )
+
+    async def manage_aws_glue_statements(
+        self,
+        ctx: Context,
+        operation: str = Field(
+            ...,
+            description='Operation to perform: run-statement, cancel-statement, get-statement, list-statements. Choose "get-statement" or "list-statements" for read-only operations when write access is disabled.',
+        ),
+        session_id: str = Field(
+            ...,
+            description="ID of the session (required for all operations).",
+        ),
+        statement_id: Optional[int] = Field(
+            None,
+            description="ID of the statement (required for cancel-statement and get-statement operations).",
+        ),
+        code: Optional[str] = Field(
+            None,
+            description="Code to execute for run-statement operation (up to 68000 characters).",
+        ),
+        request_origin: Optional[str] = Field(
+            None,
+            description="Origin of the request (optional for all operations).",
+        ),
+        max_results: Optional[int] = Field(
+            None,
+            description="Maximum number of results to return for list-statements operation.",
+        ),
+        next_token: Optional[str] = Field(
+            None,
+            description="Pagination token for list-statements operation.",
+        ),
+    ) -> Union[
+        RunStatementResponse,
+        CancelStatementResponse,
+        GetStatementResponse,
+        ListStatementsResponse,
+    ]:
+        """Manage AWS Glue Interactive Session Statements for executing code and retrieving results.
+
+        This tool provides operations for executing code, canceling running statements, and retrieving
+        results within Glue Interactive Sessions. It enables interactive data processing, exploration,
+        and analysis using Spark or Ray in AWS Glue.
+
+        ## Requirements
+        - The server must be run with the `--allow-write` flag for run-statement and cancel-statement operations
+        - Appropriate AWS permissions for Glue Interactive Session Statement operations
+        - A valid session ID is required for all operations
+
+        ## Operations
+        - **run-statement**: Execute code in an interactive session and get a statement ID
+        - **cancel-statement**: Cancel a running statement by ID
+        - **get-statement**: Retrieve detailed information and results of a specific statement
+        - **list-statements**: List all statements in a session with their status
+
+        ## Example
+        ```python
+        # Run a PySpark statement in a session
+        {
+          "operation": "run-statement",
+          "session_id": "my-spark-session",
+          "code": "df = spark.read.csv('s3://my-bucket/data.csv', header=True)\ndf.show(5)"
+        }
+        ```
+
+        Args:
+            ctx: MCP context
+            operation: Operation to perform
+            session_id: ID of the session
+            statement_id: ID of the statement
+            code: Code to execute for run-statement operation
+            request_origin: Origin of the request
+            max_results: Maximum number of results to return
+            next_token: Pagination token
+
+        Returns:
+            Union of response types specific to the operation performed
+        """
+        try:
+            if not self.allow_write and operation not in [
+                "get-statement",
+                "list-statements",
+            ]:
+                error_message = (
+                    f"Operation {operation} is not allowed without write access"
+                )
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+
+                if operation == "run-statement":
+                    return RunStatementResponse(
+                        isError=True,
+                        content=[TextContent(type="text", text=error_message)],
+                        session_id="",
+                        statement_id=0,
+                    )
+                elif operation == "cancel-statement":
+                    return CancelStatementResponse(
+                        isError=True,
+                        content=[TextContent(type="text", text=error_message)],
+                        session_id="",
+                        statement_id=0,
+                    )
+
+            if operation == "run-statement":
+                if code is None:
+                    raise ValueError("code is required for run-statement operation")
+
+                # Prepare run statement parameters
+                run_params = {
+                    "SessionId": session_id,
+                    "Code": code,
+                }
+                if request_origin:
+                    run_params["RequestOrigin"] = request_origin
+
+                # Run the statement
+                response = self.glue_client.run_statement(**run_params)
+
+                return RunStatementResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully ran statement in session {session_id}",
+                        )
+                    ],
+                    session_id=session_id,
+                    statement_id=response.get("Id", 0),
+                )
+
+            elif operation == "cancel-statement":
+                if statement_id is None:
+                    raise ValueError(
+                        "statement_id is required for cancel-statement operation"
+                    )
+
+                # Prepare cancel statement parameters
+                cancel_params = {
+                    "SessionId": session_id,
+                    "Id": statement_id,
+                }
+                if request_origin:
+                    cancel_params["RequestOrigin"] = request_origin
+
+                # Cancel the statement
+                self.glue_client.cancel_statement(**cancel_params)
+
+                return CancelStatementResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully canceled statement {statement_id} in session {session_id}",
+                        )
+                    ],
+                    session_id=session_id,
+                    statement_id=statement_id,
+                )
+
+            elif operation == "get-statement":
+                if statement_id is None:
+                    raise ValueError(
+                        "statement_id is required for get-statement operation"
+                    )
+
+                # Prepare get statement parameters
+                get_params = {
+                    "SessionId": session_id,
+                    "Id": statement_id,
+                }
+                if request_origin:
+                    get_params["RequestOrigin"] = request_origin
+
+                # Get the statement
+                response = self.glue_client.get_statement(**get_params)
+
+                return GetStatementResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully retrieved statement {statement_id} in session {session_id}",
+                        )
+                    ],
+                    session_id=session_id,
+                    statement_id=statement_id,
+                    statement=response.get("Statement", {}),
+                )
+
+            elif operation == "list-statements":
+                # Prepare list statements parameters
+                params = {"SessionId": session_id}
+                if max_results is not None:
+                    params["MaxResults"] = str(max_results)
+                if next_token is not None:
+                    params["NextToken"] = next_token
+                if request_origin:
+                    params["RequestOrigin"] = request_origin
+
+                # List statements
+                response = self.glue_client.list_statements(**params)
+
+                return ListStatementsResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully retrieved statements for session {session_id}",
+                        )
+                    ],
+                    session_id=session_id,
+                    statements=response.get("Statements", []),
+                    next_token=response.get("NextToken"),
+                    count=len(response.get("Statements", [])),
+                )
+
+            else:
+                error_message = f"Invalid operation: {operation}. Must be one of: run-statement, cancel-statement, get-statement, list-statements"
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                return GetStatementResponse(
+                    isError=True,
+                    content=[TextContent(type="text", text=error_message)],
+                    session_id=session_id,
+                    statement_id=statement_id or 0,
+                    statement={},
+                )
+
+        except ValueError as e:
+            log_with_request_id(
+                ctx, LogLevel.ERROR, f"Parameter validation error: {str(e)}"
+            )
+            raise
+        except Exception as e:
+            error_message = f"Error in manage_aws_glue_statements: {str(e)}"
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+            return GetStatementResponse(
+                isError=True,
+                content=[TextContent(type="text", text=error_message)],
+                session_id=session_id,
+                statement_id=statement_id or 0,
+                statement={},
+            )

--- a/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/handlers/glue/glue_worklows_handler.py
+++ b/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/handlers/glue/glue_worklows_handler.py
@@ -1,0 +1,945 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GlueEtlJobsHandler for Data Processing MCP Server."""
+
+import os
+from awslabs.dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.dataprocessing_mcp_server.utils.logging_helper import (
+    LogLevel,
+    log_with_request_id,
+)
+from awslabs.dataprocessing_mcp_server.models.glue_models import (
+    CreateWorkflowResponse,
+    DeleteWorkflowResponse,
+    GetWorkflowResponse,
+    ListWorkflowsResponse,
+    StartWorkflowRunResponse,
+    CreateTriggerResponse,
+    DeleteTriggerResponse,
+    GetTriggerResponse,
+    GetTriggersResponse,
+    StartTriggerResponse,
+    StopTriggerResponse,
+)
+
+from mcp.server.fastmcp import Context
+from mcp.types import TextContent
+from pydantic import Field, BaseModel
+from typing import Dict, List, Optional, Tuple, Union, cast, Any
+from botocore.exceptions import ClientError
+
+
+class GlueWorkflowAndTriggerHandler:
+    """Handler for Amazon Glue ETL Jobs operations."""
+
+    def __init__(
+        self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False
+    ):
+        """Initialize the Glue ETL Jobs handler.
+
+        Args:
+            mcp: The MCP server instance
+            allow_write: Whether to enable write access (default: False)
+            allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+        """
+        self.mcp = mcp
+        self.allow_write = allow_write
+        self.allow_sensitive_data_access = allow_sensitive_data_access
+        self.glue_client = AwsHelper.create_boto3_client("glue")
+
+        # Register tools
+        self.mcp.tool(name="manage_aws_glue_workflows")(self.manage_aws_glue_workflows)
+        self.mcp.tool(name="manage_aws_glue_triggers")(self.manage_aws_glue_triggers)
+
+    async def manage_aws_glue_workflows(
+        self,
+        ctx: Context,
+        operation: str = Field(
+            ...,
+            description='Operation to perform: create-workflow, delete-workflow, get-workflow, list-workflows, start-workflow-run. Choose "get-workflow" or "list-workflows" for read-only operations when write access is disabled.',
+        ),
+        workflow_name: Optional[str] = Field(
+            None,
+            description="Name of the workflow (required for all operations except list-workflows).",
+        ),
+        workflow_definition: Optional[Dict[str, Any]] = Field(
+            None,
+            description="Workflow definition for create-workflow operation.",
+        ),
+        max_results: Optional[int] = Field(
+            None,
+            description="Maximum number of results to return for list-workflows operation.",
+        ),
+        next_token: Optional[str] = Field(
+            None,
+            description="Pagination token for list-workflows operation.",
+        ),
+    ) -> Union[
+        CreateWorkflowResponse,
+        DeleteWorkflowResponse,
+        GetWorkflowResponse,
+        ListWorkflowsResponse,
+        StartWorkflowRunResponse,
+    ]:
+        """Manage AWS Glue workflows to orchestrate complex ETL activities.
+
+        This tool allows you to create, delete, retrieve, list, and start AWS Glue workflows.
+        Workflows help you design and visualize complex ETL activities as a series of dependent
+        jobs and crawlers, making it easier to manage and monitor your data processing pipelines.
+
+        ## Requirements
+        - The server must be run with the `--allow-write` flag for create-workflow, delete-workflow, and start-workflow-run operations
+        - Appropriate AWS permissions for Glue workflow operations
+
+        ## Operations
+        - **create-workflow**: Create a new workflow with optional description, default run properties, tags, and max concurrent runs
+        - **delete-workflow**: Delete an existing workflow by name
+        - **get-workflow**: Retrieve detailed information about a specific workflow with optional graph inclusion
+        - **list-workflows**: List all workflows with pagination support
+        - **start-workflow-run**: Start a workflow run with optional run properties
+
+        ## Example
+        ```python
+        # Create a new workflow
+        manage_aws_glue_workflows(
+            operation="create-workflow",
+            workflow_name="my-etl-workflow",
+            workflow_definition={
+                "Description": "ETL workflow for daily data processing",
+                "DefaultRunProperties": {"ENV": "production"},
+                "MaxConcurrentRuns": 1
+            }
+        )
+
+        # Start a workflow run
+        manage_aws_glue_workflows(
+            operation="start-workflow-run",
+            workflow_name="my-etl-workflow",
+            workflow_definition={
+                "run_properties": {"EXECUTION_DATE": "2023-06-19"}
+            }
+        )
+        ```
+
+        Args:
+            ctx: MCP context
+            operation: Operation to perform
+            workflow_name: Name of the workflow
+            workflow_definition: Workflow definition for create-workflow operation
+            max_results: Maximum number of results to return for list-workflows operation
+            next_token: Pagination token for list-workflows operation
+
+        Returns:
+            Union of response types specific to the operation performed
+        """
+        try:
+            if not self.allow_write and operation not in [
+                "get-workflow",
+                "list-workflows",
+            ]:
+                error_message = (
+                    f"Operation {operation} is not allowed without write access"
+                )
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+
+                if operation == "create-workflow":
+                    return CreateWorkflowResponse(
+                        isError=True,
+                        content=[TextContent(type="text", text=error_message)],
+                        workflow_name="",
+                    )
+                elif operation == "delete-workflow":
+                    return DeleteWorkflowResponse(
+                        isError=True,
+                        content=[TextContent(type="text", text=error_message)],
+                        workflow_name="",
+                    )
+                elif operation == "start-workflow-run":
+                    return StartWorkflowRunResponse(
+                        isError=True,
+                        content=[TextContent(type="text", text=error_message)],
+                        workflow_name="",
+                        run_id="",
+                    )
+
+            if operation == "create-workflow":
+                if workflow_name is None or workflow_definition is None:
+                    raise ValueError(
+                        "workflow_name and workflow_definition are required for create-workflow operation"
+                    )
+
+                # Create the workflow
+                # Extract specific parameters from workflow_definition
+                params = {}
+                if "Description" in workflow_definition:
+                    params["Description"] = workflow_definition.get("Description")
+                if "DefaultRunProperties" in workflow_definition:
+                    params["DefaultRunProperties"] = workflow_definition.get(
+                        "DefaultRunProperties"
+                    )
+
+                # Add MCP management tags
+                resource_tags = AwsHelper.prepare_resource_tags("GlueWorkflow")
+
+                # Merge user-provided tags with MCP tags
+                if "Tags" in workflow_definition:
+                    user_tags = workflow_definition.get("Tags", {})
+                    merged_tags = user_tags.copy()
+                    merged_tags.update(resource_tags)
+                    params["Tags"] = merged_tags
+                else:
+                    params["Tags"] = resource_tags
+
+                if "MaxConcurrentRuns" in workflow_definition:
+                    params["MaxConcurrentRuns"] = workflow_definition.get(
+                        "MaxConcurrentRuns"
+                    )
+
+                response = self.glue_client.create_workflow(
+                    Name=workflow_name, **params
+                )
+
+                return CreateWorkflowResponse(
+                    isError=False,
+                    content=cast(
+                        List[TextContent],
+                        [
+                            TextContent(
+                                type="text",
+                                text=f"Successfully created workflow {workflow_name}",
+                            )
+                        ],
+                    ),
+                    workflow_name=workflow_name,
+                )
+
+            elif operation == "delete-workflow":
+                if workflow_name is None:
+                    raise ValueError(
+                        "workflow_name is required for delete-workflow operation"
+                    )
+
+                # First check if the workflow is managed by MCP
+                try:
+                    # Get the workflow to check if it's managed by MCP
+                    response = self.glue_client.get_workflow(Name=workflow_name)
+                    workflow = response.get("Workflow", {})
+                    tags = workflow.get("Tags", {})
+
+                    # Construct the ARN for the workflow
+                    region = AwsHelper.get_aws_region() or "us-east-1"
+                    account_id = AwsHelper.get_aws_account_id()
+                    workflow_arn = (
+                        f"arn:aws:glue:{region}:{account_id}:workflow/{workflow_name}"
+                    )
+
+                    # Check if the workflow is managed by MCP
+                    if not AwsHelper.is_resource_mcp_managed(
+                        self.glue_client, workflow_arn, {}
+                    ):
+                        error_message = f"Cannot delete workflow {workflow_name} - it is not managed by the MCP server (missing required tags)"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return DeleteWorkflowResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            workflow_name=workflow_name,
+                        )
+                except ClientError as e:
+                    if e.response["Error"]["Code"] == "EntityNotFoundException":
+                        error_message = f"Workflow {workflow_name} not found"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return DeleteWorkflowResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            workflow_name=workflow_name,
+                        )
+                    else:
+                        raise e
+
+                # Delete the workflow
+                self.glue_client.delete_workflow(Name=workflow_name)
+
+                return DeleteWorkflowResponse(
+                    isError=False,
+                    content=cast(
+                        List[TextContent],
+                        [
+                            TextContent(
+                                type="text",
+                                text=f"Successfully deleted workflow {workflow_name}",
+                            )
+                        ],
+                    ),
+                    workflow_name=workflow_name,
+                )
+
+            elif operation == "get-workflow":
+                if workflow_name is None:
+                    raise ValueError(
+                        "workflow_name is required for get-workflow operation"
+                    )
+
+                # Get the workflow
+                params = {"Name": workflow_name}
+
+                # Add optional parameter
+                if (
+                    workflow_definition is not None
+                    and isinstance(workflow_definition, dict)
+                    and "include_graph" in workflow_definition
+                    and workflow_definition["include_graph"]
+                ):
+                    params["IncludeGraph"] = workflow_definition["include_graph"]
+
+                response = self.glue_client.get_workflow(**params)
+
+                return GetWorkflowResponse(
+                    isError=False,
+                    content=cast(
+                        List[TextContent],
+                        [
+                            TextContent(
+                                type="text",
+                                text=f"Successfully retrieved workflow {workflow_name}",
+                            )
+                        ],
+                    ),
+                    workflow_name=workflow_name,
+                    workflow_details=response.get("Workflow", {}),
+                )
+
+            elif operation == "list-workflows":
+                # Prepare parameters
+                params: Dict[str, Any] = {}
+                if max_results is not None:
+                    params["MaxResults"] = max_results
+                if next_token is not None:
+                    params["NextToken"] = next_token
+
+                # Get workflows
+                response = self.glue_client.list_workflows(**params)
+                
+                # Convert workflow names to dictionary format
+                workflow_names = response.get("Workflows", [])
+                workflows = [{"Name": name} for name in workflow_names]
+
+                return ListWorkflowsResponse(
+                    isError=False,
+                    content=cast(
+                        List[TextContent],
+                        [
+                            TextContent(
+                                type="text", text="Successfully retrieved workflows"
+                            )
+                        ],
+                    ),
+                    workflows=workflows,
+                    next_token=response.get("NextToken"),
+                )
+
+            elif operation == "start-workflow-run":
+                if workflow_name is None:
+                    raise ValueError(
+                        "workflow_name is required for start-workflow-run operation"
+                    )
+
+                # First check if the workflow is managed by MCP
+                try:
+                    # Get the workflow to check if it's managed by MCP
+                    response = self.glue_client.get_workflow(Name=workflow_name)
+                    workflow = response.get("Workflow", {})
+                    tags = workflow.get("Tags", {})
+
+                    # Construct the ARN for the workflow
+                    region = AwsHelper.get_aws_region() or "us-east-1"
+                    account_id = AwsHelper.get_aws_account_id()
+                    workflow_arn = (
+                        f"arn:aws:glue:{region}:{account_id}:workflow/{workflow_name}"
+                    )
+
+                    # Check if the workflow is managed by MCP
+                    if not AwsHelper.is_resource_mcp_managed(
+                        self.glue_client, workflow_arn, {}
+                    ):
+                        error_message = f"Cannot start workflow run for {workflow_name} - it is not managed by the MCP server (missing required tags)"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return StartWorkflowRunResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            workflow_name=workflow_name,
+                            run_id="",
+                        )
+                except ClientError as e:
+                    if e.response["Error"]["Code"] == "EntityNotFoundException":
+                        error_message = f"Workflow {workflow_name} not found"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return StartWorkflowRunResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            workflow_name=workflow_name,
+                            run_id="",
+                        )
+                    else:
+                        raise e
+
+                # Start workflow run
+                params = {"Name": workflow_name}
+
+                # Add optional run properties if provided
+                if (
+                    workflow_definition is not None
+                    and isinstance(workflow_definition, dict)
+                    and "run_properties" in workflow_definition
+                    and workflow_definition["run_properties"]
+                ):
+                    params["RunProperties"] = workflow_definition["run_properties"]
+
+                response = self.glue_client.start_workflow_run(**params)
+
+                return StartWorkflowRunResponse(
+                    isError=False,
+                    content=cast(
+                        List[TextContent],
+                        [
+                            TextContent(
+                                type="text",
+                                text=f"Successfully started workflow run for {workflow_name}",
+                            )
+                        ],
+                    ),
+                    workflow_name=workflow_name,
+                    run_id=response.get("RunId", ""),
+                )
+
+            else:
+                error_message = f"Invalid operation: {operation}. Must be one of: create-workflow, delete-workflow, get-workflow, list-workflows, start-workflow-run"
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                return GetWorkflowResponse(
+                    isError=True,
+                    content=cast(
+                        List[TextContent],
+                        [TextContent(type="text", text=error_message)],
+                    ),
+                    workflow_name=workflow_name or "",
+                    workflow_details={},
+                )
+
+        except ValueError as e:
+            log_with_request_id(
+                ctx, LogLevel.ERROR, f"Parameter validation error: {str(e)}"
+            )
+            raise
+        except Exception as e:
+            error_message = f"Error in manage_aws_glue_workflows: {str(e)}"
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+            return GetWorkflowResponse(
+                isError=True,
+                content=cast(
+                    List[TextContent],
+                    [TextContent(type="text", text=error_message)],
+                ),
+                workflow_name=workflow_name or "",
+                workflow_details={},
+            )
+
+    async def manage_aws_glue_triggers(
+        self,
+        ctx: Context,
+        operation: str = Field(
+            ...,
+            description='Operation to perform: create-trigger, delete-trigger, get-trigger, get-triggers, start-trigger, stop-trigger. Choose "get-trigger" or "get-triggers" for read-only operations when write access is disabled.',
+        ),
+        trigger_name: Optional[str] = Field(
+            None,
+            description="Name of the trigger (required for all operations except get-triggers).",
+        ),
+        trigger_definition: Optional[Dict[str, Any]] = Field(
+            None,
+            description="Trigger definition for create-trigger operation.",
+        ),
+        max_results: Optional[int] = Field(
+            None,
+            description="Maximum number of results to return for get-triggers operation.",
+        ),
+        next_token: Optional[str] = Field(
+            None,
+            description="Pagination token for get-triggers operation.",
+        ),
+    ) -> Union[
+        CreateTriggerResponse,
+        DeleteTriggerResponse,
+        GetTriggerResponse,
+        GetTriggersResponse,
+        StartTriggerResponse,
+        StopTriggerResponse,
+    ]:
+        """Manage AWS Glue triggers to automate workflow and job execution.
+
+        This tool allows you to create, delete, retrieve, list, start, and stop AWS Glue triggers.
+        Triggers define the conditions that automatically start jobs or workflows, enabling
+        scheduled or event-based execution of your ETL processes.
+
+        ## Requirements
+        - The server must be run with the `--allow-write` flag for create-trigger, delete-trigger, start-trigger, and stop-trigger operations
+        - Appropriate AWS permissions for Glue trigger operations
+
+        ## Operations
+        - **create-trigger**: Create a new trigger with specified type (SCHEDULED, CONDITIONAL, ON_DEMAND, EVENT) and actions
+        - **delete-trigger**: Delete an existing trigger by name
+        - **get-trigger**: Retrieve detailed information about a specific trigger
+        - **get-triggers**: List all triggers with pagination support
+        - **start-trigger**: Activate a trigger to begin monitoring for its firing conditions
+        - **stop-trigger**: Deactivate a trigger to pause its monitoring
+
+        ## Trigger Types
+        - **SCHEDULED**: Time-based triggers that run on a cron schedule
+        - **CONDITIONAL**: Event-based triggers that run when specified conditions are met
+        - **ON_DEMAND**: Manually activated triggers
+        - **EVENT**: EventBridge event-based triggers
+
+        ## Example
+        ```python
+        # Create a scheduled trigger
+        manage_aws_glue_triggers(
+            operation="create-trigger",
+            trigger_name="daily-etl-trigger",
+            trigger_definition={
+                "Type": "SCHEDULED",
+                "Schedule": "cron(0 12 * * ? *)",  # Run daily at 12:00 UTC
+                "Actions": [
+                    {
+                        "JobName": "process-daily-data"
+                    }
+                ],
+                "Description": "Trigger for daily ETL job",
+                "StartOnCreation": True
+            }
+        )
+
+        # Create a conditional trigger
+        manage_aws_glue_triggers(
+            operation="create-trigger",
+            trigger_name="data-arrival-trigger",
+            trigger_definition={
+                "Type": "CONDITIONAL",
+                "Actions": [
+                    {
+                        "JobName": "process-new-data"
+                    }
+                ],
+                "Predicate": {
+                    "Conditions": [
+                        {
+                            "LogicalOperator": "EQUALS",
+                            "JobName": "crawl-new-data",
+                            "State": "SUCCEEDED"
+                        }
+                    ]
+                },
+                "Description": "Trigger that runs when data crawling completes"
+            }
+        )
+        ```
+
+        Args:
+            ctx: MCP context
+            operation: Operation to perform
+            trigger_name: Name of the trigger
+            trigger_definition: Trigger definition for create-trigger operation
+            max_results: Maximum number of results to return for get-triggers operation
+            next_token: Pagination token for get-triggers operation
+
+        Returns:
+            Union of response types specific to the operation performed
+        """
+        try:
+            if not self.allow_write and operation not in [
+                "get-trigger",
+                "get-triggers",
+            ]:
+                error_message = (
+                    f"Operation {operation} is not allowed without write access"
+                )
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+
+                if operation == "create-trigger":
+                    return CreateTriggerResponse(
+                        isError=True,
+                        content=cast(
+                            List[TextContent],
+                            [TextContent(type="text", text=error_message)],
+                        ),
+                        trigger_name="",
+                    )
+                elif operation == "delete-trigger":
+                    return DeleteTriggerResponse(
+                        isError=True,
+                        content=cast(
+                            List[TextContent],
+                            [TextContent(type="text", text=error_message)],
+                        ),
+                        trigger_name="",
+                    )
+                elif operation == "start-trigger":
+                    return StartTriggerResponse(
+                        isError=True,
+                        content=cast(
+                            List[TextContent],
+                            [TextContent(type="text", text=error_message)],
+                        ),
+                        trigger_name="",
+                    )
+                elif operation == "stop-trigger":
+                    return StopTriggerResponse(
+                        isError=True,
+                        content=cast(
+                            List[TextContent],
+                            [TextContent(type="text", text=error_message)],
+                        ),
+                        trigger_name="",
+                    )
+                else:
+                    return GetTriggerResponse(
+                        isError=True,
+                        content=cast(
+                            List[TextContent],
+                            [TextContent(type="text", text=error_message)],
+                        ),
+                        trigger_name="",
+                        trigger_details={},
+                    )
+
+            if operation == "create-trigger":
+                if trigger_name is None or trigger_definition is None:
+                    raise ValueError(
+                        "trigger_name and trigger_definition are required for create-trigger operation"
+                    )
+
+                # Create the trigger
+                # Extract specific parameters from trigger_definition
+                params = {
+                    "Name": trigger_name,
+                    "Type": trigger_definition.get("Type"),
+                    "Actions": trigger_definition.get("Actions"),
+                }
+
+                # Add optional parameters if provided
+                if "WorkflowName" in trigger_definition:
+                    params["WorkflowName"] = trigger_definition.get("WorkflowName")
+                if "Schedule" in trigger_definition:
+                    params["Schedule"] = trigger_definition.get("Schedule")
+                if "Predicate" in trigger_definition:
+                    params["Predicate"] = trigger_definition.get("Predicate")
+                if "Description" in trigger_definition:
+                    params["Description"] = trigger_definition.get("Description")
+                if "StartOnCreation" in trigger_definition:
+                    params["StartOnCreation"] = trigger_definition.get(
+                        "StartOnCreation"
+                    )
+
+                # Add MCP management tags
+                resource_tags = AwsHelper.prepare_resource_tags("GlueTrigger")
+
+                # Merge user-provided tags with MCP tags
+                if "Tags" in trigger_definition:
+                    user_tags = trigger_definition.get("Tags", {})
+                    merged_tags = user_tags.copy()
+                    merged_tags.update(resource_tags)
+                    params["Tags"] = merged_tags
+                else:
+                    params["Tags"] = resource_tags
+
+                if "EventBatchingCondition" in trigger_definition:
+                    params["EventBatchingCondition"] = trigger_definition.get(
+                        "EventBatchingCondition"
+                    )
+
+                response = self.glue_client.create_trigger(**params)
+
+                return CreateTriggerResponse(
+                    isError=False,
+                    content=cast(
+                        List[TextContent],
+                        [
+                            TextContent(
+                                type="text",
+                                text=f"Successfully created trigger {trigger_name}",
+                            )
+                        ],
+                    ),
+                    trigger_name=trigger_name,
+                )
+
+            elif operation == "delete-trigger":
+                if trigger_name is None:
+                    raise ValueError(
+                        "trigger_name is required for delete-trigger operation"
+                    )
+
+                # First check if the trigger is managed by MCP
+                try:
+                    # Get the trigger to check if it's managed by MCP
+                    response = self.glue_client.get_trigger(Name=trigger_name)
+                    trigger = response.get("Trigger", {})
+                    tags = trigger.get("Tags", {})
+
+                    # Construct the ARN for the trigger
+                    region = AwsHelper.get_aws_region() or "us-east-1"
+                    account_id = AwsHelper.get_aws_account_id()
+                    trigger_arn = (
+                        f"arn:aws:glue:{region}:{account_id}:trigger/{trigger_name}"
+                    )
+
+                    # Check if the trigger is managed by MCP
+                    if not AwsHelper.is_resource_mcp_managed(
+                        self.glue_client, trigger_arn, {}
+                    ):
+                        error_message = f"Cannot delete trigger {trigger_name} - it is not managed by the MCP server (missing required tags)"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return DeleteTriggerResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            trigger_name=trigger_name,
+                        )
+                except ClientError as e:
+                    if e.response["Error"]["Code"] == "EntityNotFoundException":
+                        error_message = f"Trigger {trigger_name} not found"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return DeleteTriggerResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            trigger_name=trigger_name,
+                        )
+                    else:
+                        raise e
+
+                # Delete the trigger
+                self.glue_client.delete_trigger(Name=trigger_name)
+
+                return DeleteTriggerResponse(
+                    isError=False,
+                    content=cast(
+                        List[TextContent],
+                        [
+                            TextContent(
+                                type="text",
+                                text=f"Successfully deleted trigger {trigger_name}",
+                            )
+                        ],
+                    ),
+                    trigger_name=trigger_name,
+                )
+
+            elif operation == "get-trigger":
+                if trigger_name is None:
+                    raise ValueError(
+                        "trigger_name is required for get-trigger operation"
+                    )
+
+                # Get the trigger
+                params = {"Name": trigger_name}
+
+                response = self.glue_client.get_trigger(**params)
+
+                return GetTriggerResponse(
+                    isError=False,
+                    content=cast(
+                        List[TextContent],
+                        [
+                            TextContent(
+                                type="text",
+                                text=f"Successfully retrieved trigger {trigger_name}",
+                            )
+                        ],
+                    ),
+                    trigger_name=trigger_name,
+                    trigger_details=response.get("Trigger", {}),
+                )
+
+            elif operation == "get-triggers":
+                # Prepare parameters
+                params: Dict[str, Any] = {}
+                if max_results is not None:
+                    params["MaxResults"] = max_results
+                if next_token is not None:
+                    params["NextToken"] = next_token
+
+                # Get triggers
+                response = self.glue_client.get_triggers(**params)
+
+                return GetTriggersResponse(
+                    isError=False,
+                    content=cast(
+                        List[TextContent],
+                        [
+                            TextContent(
+                                type="text", text="Successfully retrieved triggers"
+                            )
+                        ],
+                    ),
+                    triggers=response.get("Triggers", []),
+                    next_token=response.get("NextToken"),
+                )
+
+            elif operation == "start-trigger":
+                if trigger_name is None:
+                    raise ValueError(
+                        "trigger_name is required for start-trigger operation"
+                    )
+
+                # First check if the trigger is managed by MCP
+                try:
+                    # Get the trigger to check if it's managed by MCP
+                    response = self.glue_client.get_trigger(Name=trigger_name)
+                    trigger = response.get("Trigger", {})
+                    tags = trigger.get("Tags", {})
+
+                    # Construct the ARN for the trigger
+                    region = AwsHelper.get_aws_region() or "us-east-1"
+                    account_id = AwsHelper.get_aws_account_id()
+                    trigger_arn = (
+                        f"arn:aws:glue:{region}:{account_id}:trigger/{trigger_name}"
+                    )
+
+                    # Check if the trigger is managed by MCP
+                    if not AwsHelper.is_resource_mcp_managed(
+                        self.glue_client, trigger_arn, {}
+                    ):
+                        error_message = f"Cannot start trigger {trigger_name} - it is not managed by the MCP server (missing required tags)"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return StartTriggerResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            trigger_name=trigger_name,
+                        )
+                except ClientError as e:
+                    if e.response["Error"]["Code"] == "EntityNotFoundException":
+                        error_message = f"Trigger {trigger_name} not found"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return StartTriggerResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            trigger_name=trigger_name,
+                        )
+                    else:
+                        raise e
+
+                # Start trigger
+                self.glue_client.start_trigger(Name=trigger_name)
+
+                return StartTriggerResponse(
+                    isError=False,
+                    content=cast(
+                        List[TextContent],
+                        [
+                            TextContent(
+                                type="text",
+                                text=f"Successfully started trigger {trigger_name}",
+                            )
+                        ],
+                    ),
+                    trigger_name=trigger_name,
+                )
+
+            elif operation == "stop-trigger":
+                if trigger_name is None:
+                    raise ValueError(
+                        "trigger_name is required for stop-trigger operation"
+                    )
+
+                # First check if the trigger is managed by MCP
+                try:
+                    # Get the trigger to check if it's managed by MCP
+                    response = self.glue_client.get_trigger(Name=trigger_name)
+                    trigger = response.get("Trigger", {})
+                    tags = trigger.get("Tags", {})
+
+                    # Construct the ARN for the trigger
+                    region = AwsHelper.get_aws_region() or "us-east-1"
+                    account_id = AwsHelper.get_aws_account_id()
+                    trigger_arn = (
+                        f"arn:aws:glue:{region}:{account_id}:trigger/{trigger_name}"
+                    )
+
+                    # Check if the trigger is managed by MCP
+                    if not AwsHelper.is_resource_mcp_managed(
+                        self.glue_client, trigger_arn, {}
+                    ):
+                        error_message = f"Cannot stop trigger {trigger_name} - it is not managed by the MCP server (missing required tags)"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return StopTriggerResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            trigger_name=trigger_name,
+                        )
+                except ClientError as e:
+                    if e.response["Error"]["Code"] == "EntityNotFoundException":
+                        error_message = f"Trigger {trigger_name} not found"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return StopTriggerResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            trigger_name=trigger_name,
+                        )
+                    else:
+                        raise e
+
+                # Stop trigger
+                self.glue_client.stop_trigger(Name=trigger_name)
+
+                return StopTriggerResponse(
+                    isError=False,
+                    content=cast(
+                        List[TextContent],
+                        [
+                            TextContent(
+                                type="text",
+                                text=f"Successfully stopped trigger {trigger_name}",
+                            )
+                        ],
+                    ),
+                    trigger_name=trigger_name,
+                )
+
+            else:
+                error_message = f"Invalid operation: {operation}. Must be one of: create-trigger, delete-trigger, get-trigger, get-triggers, start-trigger, stop-trigger"
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                return GetTriggerResponse(
+                    isError=True,
+                    content=cast(
+                        List[TextContent],
+                        [TextContent(type="text", text=error_message)],
+                    ),
+                    trigger_name=trigger_name or "",
+                    trigger_details={},
+                )
+
+        except ValueError as e:
+            log_with_request_id(
+                ctx, LogLevel.ERROR, f"Parameter validation error: {str(e)}"
+            )
+            raise
+        except Exception as e:
+            error_message = f"Error in manage_aws_glue_triggers: {str(e)}"
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+            return GetTriggerResponse(
+                isError=True,
+                content=cast(
+                    List[TextContent],
+                    [TextContent(type="text", text=error_message)],
+                ),
+                trigger_name=trigger_name or "",
+                trigger_details={},
+            )

--- a/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/models/glue_models.py
+++ b/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/models/glue_models.py
@@ -95,7 +95,7 @@ class CreateWorkflowResponse(CallToolResult):
     isError: bool = Field(..., description="Whether the operation resulted in an error")
     content: List[TextContent] = Field(..., description="Content of the response")
     workflow_name: str = Field(..., description="Name of the created workflow")
-    operation: str = Field(default="create", description="Operation performed")
+    operation: str = Field(default="create-workflow", description="Creates a new workflow.")
 
 
 class DeleteWorkflowResponse(CallToolResult):
@@ -104,7 +104,7 @@ class DeleteWorkflowResponse(CallToolResult):
     isError: bool = Field(..., description="Whether the operation resulted in an error")
     content: List[TextContent] = Field(..., description="Content of the response")
     workflow_name: str = Field(..., description="Name of the deleted workflow")
-    operation: str = Field(default="delete", description="Operation performed")
+    operation: str = Field(default="delete-workflow", description="Deletes a workflow.")
 
 
 class GetWorkflowResponse(CallToolResult):
@@ -116,17 +116,17 @@ class GetWorkflowResponse(CallToolResult):
     workflow_details: Dict[str, Any] = Field(
         ..., description="Complete workflow definition"
     )
-    operation: str = Field(default="get", description="Operation performed")
+    operation: str = Field(default="get-workflow", description="Retrieves resource metadata for a workflow.")
 
 
-class GetWorkflowsResponse(CallToolResult):
+class ListWorkflowsResponse(CallToolResult):
     """Response model for get workflows operation."""
 
     isError: bool = Field(..., description="Whether the operation resulted in an error")
     content: List[TextContent] = Field(..., description="Content of the response")
     workflows: List[Dict[str, Any]] = Field(..., description="List of workflows")
     next_token: Optional[str] = Field(None, description="Token for pagination")
-    operation: str = Field(default="list", description="Operation performed")
+    operation: str = Field(default="list-workflows", description="Lists names of workflows created in the account.")
 
 
 class StartWorkflowRunResponse(CallToolResult):
@@ -136,7 +136,7 @@ class StartWorkflowRunResponse(CallToolResult):
     content: List[TextContent] = Field(..., description="Content of the response")
     workflow_name: str = Field(..., description="Name of the workflow")
     run_id: str = Field(..., description="ID of the workflow run")
-    operation: str = Field(default="start_run", description="Operation performed")
+    operation: str = Field(default="start-workflow-run", description="Starts a new run of the specified workflow.")
 
 
 # Response models for Triggers
@@ -146,7 +146,7 @@ class CreateTriggerResponse(CallToolResult):
     isError: bool = Field(..., description="Whether the operation resulted in an error")
     content: List[TextContent] = Field(..., description="Content of the response")
     trigger_name: str = Field(..., description="Name of the created trigger")
-    operation: str = Field(default="create", description="Operation performed")
+    operation: str = Field(default="create-trigger", description="Creates a new trigger.")
 
 
 class DeleteTriggerResponse(CallToolResult):
@@ -155,7 +155,7 @@ class DeleteTriggerResponse(CallToolResult):
     isError: bool = Field(..., description="Whether the operation resulted in an error")
     content: List[TextContent] = Field(..., description="Content of the response")
     trigger_name: str = Field(..., description="Name of the deleted trigger")
-    operation: str = Field(default="delete", description="Operation performed")
+    operation: str = Field(default="delete-trigger", description="Deletes a specified trigger. If the trigger is not found, no exception is thrown.")
 
 
 class GetTriggerResponse(CallToolResult):
@@ -167,7 +167,7 @@ class GetTriggerResponse(CallToolResult):
     trigger_details: Dict[str, Any] = Field(
         ..., description="Complete trigger definition"
     )
-    operation: str = Field(default="get", description="Operation performed")
+    operation: str = Field(default="get-trigger", description="Retrieves the definition of a trigger.")
 
 
 class GetTriggersResponse(CallToolResult):
@@ -177,7 +177,7 @@ class GetTriggersResponse(CallToolResult):
     content: List[TextContent] = Field(..., description="Content of the response")
     triggers: List[Dict[str, Any]] = Field(..., description="List of triggers")
     next_token: Optional[str] = Field(None, description="Token for pagination")
-    operation: str = Field(default="list", description="Operation performed")
+    operation: str = Field(default="get-triggers", description="Gets all the triggers associated with a job.")
 
 
 class StartTriggerResponse(CallToolResult):
@@ -186,7 +186,7 @@ class StartTriggerResponse(CallToolResult):
     isError: bool = Field(..., description="Whether the operation resulted in an error")
     content: List[TextContent] = Field(..., description="Content of the response")
     trigger_name: str = Field(..., description="Name of the trigger")
-    operation: str = Field(default="start", description="Operation performed")
+    operation: str = Field(default="start-trigger", description="Starts an existing trigger.")
 
 
 class StopTriggerResponse(CallToolResult):
@@ -195,7 +195,7 @@ class StopTriggerResponse(CallToolResult):
     isError: bool = Field(..., description="Whether the operation resulted in an error")
     content: List[TextContent] = Field(..., description="Content of the response")
     trigger_name: str = Field(..., description="Name of the trigger")
-    operation: str = Field(default="stop", description="Operation performed")
+    operation: str = Field(default="stop-trigger", description="Stops a specified trigger.")
 
 
 # Response models for Job Runs
@@ -272,7 +272,7 @@ class CreateSessionResponse(CallToolResult):
     session: Optional[Dict[str, Any]] = Field(
         None, description="Complete session object"
     )
-    operation: str = Field(default="create", description="Operation performed")
+    operation: str = Field(default="create-session", description="Created a new session.")
 
 
 class DeleteSessionResponse(CallToolResult):
@@ -281,7 +281,7 @@ class DeleteSessionResponse(CallToolResult):
     isError: bool = Field(..., description="Whether the operation resulted in an error")
     content: List[TextContent] = Field(..., description="Content of the response")
     session_id: str = Field(..., description="ID of the deleted session")
-    operation: str = Field(default="delete", description="Operation performed")
+    operation: str = Field(default="delete-session", description="Deleted the session.")
 
 
 class GetSessionResponse(CallToolResult):
@@ -293,7 +293,7 @@ class GetSessionResponse(CallToolResult):
     session: Optional[Dict[str, Any]] = Field(
         None, description="Complete session object"
     )
-    operation: str = Field(default="get", description="Operation performed")
+    operation: str = Field(default="get-session", description="Retrieves the session.")
 
 
 class ListSessionsResponse(CallToolResult):
@@ -305,7 +305,7 @@ class ListSessionsResponse(CallToolResult):
     ids: Optional[List[str]] = Field(None, description="List of session IDs")
     count: int = Field(..., description="Number of sessions found")
     next_token: Optional[str] = Field(None, description="Token for pagination")
-    operation: str = Field(default="list", description="Operation performed")
+    operation: str = Field(default="list-sessions", description="Retrieve a list of sessions.")
 
 
 class StopSessionResponse(CallToolResult):
@@ -314,7 +314,7 @@ class StopSessionResponse(CallToolResult):
     isError: bool = Field(..., description="Whether the operation resulted in an error")
     content: List[TextContent] = Field(..., description="Content of the response")
     session_id: str = Field(..., description="ID of the stopped session")
-    operation: str = Field(default="stop", description="Operation performed")
+    operation: str = Field(default="stop-session", description="Stops the session.")
 
 
 # Response models for Statements
@@ -325,7 +325,7 @@ class RunStatementResponse(CallToolResult):
     content: List[TextContent] = Field(..., description="Content of the response")
     session_id: str = Field(..., description="ID of the session")
     statement_id: int = Field(..., description="ID of the statement")
-    operation: str = Field(default="run", description="Operation performed")
+    operation: str = Field(default="run-statement", description="Executes the statement.")
 
 
 class CancelStatementResponse(CallToolResult):
@@ -335,7 +335,7 @@ class CancelStatementResponse(CallToolResult):
     content: List[TextContent] = Field(..., description="Content of the response")
     session_id: str = Field(..., description="ID of the session")
     statement_id: int = Field(..., description="ID of the canceled statement")
-    operation: str = Field(default="cancel", description="Operation performed")
+    operation: str = Field(default="cancel-statement", description="Cancels the statement.")
 
 
 class GetStatementResponse(CallToolResult):
@@ -348,7 +348,7 @@ class GetStatementResponse(CallToolResult):
     statement: Optional[Dict[str, Any]] = Field(
         None, description="Complete statement definition"
     )
-    operation: str = Field(default="get", description="Operation performed")
+    operation: str = Field(default="get-statement", description="Retrieves the statement.")
 
 
 class ListStatementsResponse(CallToolResult):
@@ -360,7 +360,7 @@ class ListStatementsResponse(CallToolResult):
     statements: List[Dict[str, Any]] = Field(..., description="List of statements")
     count: int = Field(..., description="Number of statements found")
     next_token: Optional[str] = Field(None, description="Token for pagination")
-    operation: str = Field(default="list", description="Operation performed")
+    operation: str = Field(default="list-statements", description="Lists statements for the session.")
 
 
 # Response models for Usage Profiles

--- a/src/dataprocessing-mcp-server/tests/handlers/glue/test_glue_interactive_sessions_handler.py
+++ b/src/dataprocessing-mcp-server/tests/handlers/glue/test_glue_interactive_sessions_handler.py
@@ -1,0 +1,990 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+# ruff: noqa: D101, D102, D103
+"""Tests for the Glue Interactive Sessions handler."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from botocore.exceptions import ClientError
+from mcp.server.fastmcp import Context
+from awslabs.dataprocessing_mcp_server.handlers.glue.glue_interactive_sessions_handler import GlueInteractiveSessionsHandler
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_glue_interactive_sessions_handler_initialization(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+
+    # Verify that create_boto3_client was called with 'glue'
+    mock_create_client.assert_called_once_with("glue")
+
+    # Verify that all tools were registered
+    assert mock_mcp.tool.call_count == 2
+
+    # Get all call args
+    call_args_list = mock_mcp.tool.call_args_list
+
+    # Get all tool names that were registered
+    tool_names = [call_args[1]["name"] for call_args in call_args_list]
+
+    # Verify that all expected tools were registered
+    assert "manage_aws_glue_sessions" in tool_names
+    assert "manage_aws_glue_statements" in tool_names
+
+
+# Tests for manage_aws_glue_sessions method
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags")
+async def test_create_session_success(mock_prepare_tags, mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Mock the resource tags
+    mock_prepare_tags.return_value = {"ManagedBy": "MCP"}
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the create_session response
+    mock_glue_client.create_session.return_value = {
+        "Session": {
+            "Id": "test-session",
+            "Status": "PROVISIONING"
+        }
+    }
+
+    # Call the manage_aws_glue_sessions method with create-session operation
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation="create-session",
+        session_id="test-session",
+        role="arn:aws:iam::123456789012:role/GlueInteractiveSessionRole",
+        command={"Name": "glueetl", "PythonVersion": "3"},
+        glue_version="3.0",
+        description="Test session",
+        timeout=60,
+        idle_timeout=30,
+        default_arguments={"--enable-glue-datacatalog": "true"},
+        connections={"Connections": ["test-connection"]},
+        max_capacity=5.0,
+        number_of_workers=2,
+        worker_type="G.1X",
+        security_configuration="test-security-config",
+        tags={"Environment": "Test"}
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully created session test-session" in result.content[0].text
+    assert result.session_id == "test-session"
+    assert result.session["Status"] == "PROVISIONING"
+
+    # Verify that create_session was called with the correct parameters
+    mock_glue_client.create_session.assert_called_once()
+    args, kwargs = mock_glue_client.create_session.call_args
+    assert kwargs["Id"] == "test-session"
+    assert kwargs["Role"] == "arn:aws:iam::123456789012:role/GlueInteractiveSessionRole"
+    assert kwargs["Command"] == {"Name": "glueetl", "PythonVersion": "3"}
+    assert kwargs["GlueVersion"] == "3.0"
+    assert kwargs["Description"] == "Test session"
+    assert kwargs["Timeout"] == 60
+    assert kwargs["IdleTimeout"] == 30
+    assert kwargs["DefaultArguments"] == {"--enable-glue-datacatalog": "true"}
+    assert kwargs["Connections"] == {"Connections": ["test-connection"]}
+    assert kwargs["MaxCapacity"] == 5.0
+    assert kwargs["NumberOfWorkers"] == 2
+    assert kwargs["WorkerType"] == "G.1X"
+    assert kwargs["SecurityConfiguration"] == "test-security-config"
+    assert "Tags" in kwargs
+    assert kwargs["Tags"]["Environment"] == "Test"
+    assert kwargs["Tags"]["ManagedBy"] == "MCP"
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_create_session_no_write_access(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server without write access
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=False)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Call the manage_aws_glue_sessions method with create-session operation
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation="create-session",
+        session_id="test-session",
+        role="arn:aws:iam::123456789012:role/GlueInteractiveSessionRole",
+        command={"Name": "glueetl", "PythonVersion": "3"}
+    )
+
+    # Verify the result indicates an error due to no write access
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Operation create-session is not allowed without write access" in result.content[0].text
+    assert result.session_id == ""
+
+    # Verify that create_session was NOT called
+    mock_glue_client.create_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed")
+async def test_delete_session_success(mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Mock the region and account ID
+    mock_get_region.return_value = "us-east-1"
+    mock_get_account_id.return_value = "123456789012"
+    
+    # Mock the is_resource_mcp_managed to return True
+    mock_is_mcp_managed.return_value = True
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_session response
+    mock_glue_client.get_session.return_value = {
+        "Session": {
+            "Id": "test-session",
+            "Status": "READY",
+            "Tags": {"ManagedBy": "MCP"}
+        }
+    }
+
+    # Call the manage_aws_glue_sessions method with delete-session operation
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation="delete-session",
+        session_id="test-session"
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully deleted session test-session" in result.content[0].text
+    assert result.session_id == "test-session"
+
+    # Verify that delete_session was called with the correct parameters
+    mock_glue_client.delete_session.assert_called_once()
+    args, kwargs = mock_glue_client.delete_session.call_args
+    assert kwargs["Id"] == "test-session"
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed")
+async def test_delete_session_not_mcp_managed(mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Mock the region and account ID
+    mock_get_region.return_value = "us-east-1"
+    mock_get_account_id.return_value = "123456789012"
+    
+    # Mock the is_resource_mcp_managed to return False
+    mock_is_mcp_managed.return_value = False
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_session response
+    mock_glue_client.get_session.return_value = {
+        "Session": {
+            "Id": "test-session",
+            "Status": "READY",
+            "Tags": {}  # No MCP tags
+        }
+    }
+
+    # Call the manage_aws_glue_sessions method with delete-session operation
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation="delete-session",
+        session_id="test-session"
+    )
+
+    # Verify the result indicates an error because the session is not MCP managed
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Cannot delete session test-session - it is not managed by the MCP server" in result.content[0].text
+    assert result.session_id == "test-session"
+
+    # Verify that delete_session was NOT called
+    mock_glue_client.delete_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_get_session_success(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_session response
+    mock_session_details = {
+        "Id": "test-session",
+        "Status": "READY",
+        "Command": {"Name": "glueetl", "PythonVersion": "3"},
+        "GlueVersion": "3.0"
+    }
+    mock_glue_client.get_session.return_value = {
+        "Session": mock_session_details
+    }
+
+    # Call the manage_aws_glue_sessions method with get-session operation
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation="get-session",
+        session_id="test-session"
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully retrieved session test-session" in result.content[0].text
+    assert result.session_id == "test-session"
+    assert result.session == mock_session_details
+
+    # Verify that get_session was called with the correct parameters
+    mock_glue_client.get_session.assert_called()
+    args, kwargs = mock_glue_client.get_session.call_args_list[-1]
+    assert kwargs["Id"] == "test-session"
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_list_sessions_success(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the list_sessions response
+    mock_glue_client.list_sessions.return_value = {
+        "Sessions": [
+            {
+                "Id": "session1",
+                "Status": "READY"
+            },
+            {
+                "Id": "session2",
+                "Status": "PROVISIONING"
+            }
+        ],
+        "Ids": ["session1", "session2"],
+        "NextToken": "next-token"
+    }
+
+    # Call the manage_aws_glue_sessions method with list-sessions operation
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation="list-sessions",
+        max_results=10,
+        next_token="token",
+        tags={"Environment": "Test"}
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully retrieved sessions" in result.content[0].text
+    assert len(result.sessions) == 2
+    assert result.sessions[0]["Id"] == "session1"
+    assert result.sessions[1]["Id"] == "session2"
+    assert result.ids == ["session1", "session2"]
+    assert result.next_token == "next-token"
+    assert result.count == 2
+
+    # Verify that list_sessions was called with the correct parameters
+    mock_glue_client.list_sessions.assert_called_once()
+    args, kwargs = mock_glue_client.list_sessions.call_args
+    assert "MaxResults" in kwargs
+    # MaxResults is converted to string in the handler
+    assert kwargs["MaxResults"] == "10"
+    assert "NextToken" in kwargs
+    assert kwargs["NextToken"] == "token"
+    assert "Tags" in kwargs
+    assert kwargs["Tags"] == {"Environment": "Test"}
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed")
+async def test_stop_session_success(mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Mock the region and account ID
+    mock_get_region.return_value = "us-east-1"
+    mock_get_account_id.return_value = "123456789012"
+    
+    # Mock the is_resource_mcp_managed to return True
+    mock_is_mcp_managed.return_value = True
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_session response
+    mock_glue_client.get_session.return_value = {
+        "Session": {
+            "Id": "test-session",
+            "Status": "READY",
+            "Tags": {"ManagedBy": "MCP"}
+        }
+    }
+
+    # Call the manage_aws_glue_sessions method with stop-session operation
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation="stop-session",
+        session_id="test-session"
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully stopped session test-session" in result.content[0].text
+    assert result.session_id == "test-session"
+
+    # Verify that stop_session was called with the correct parameters
+    mock_glue_client.stop_session.assert_called_once()
+    args, kwargs = mock_glue_client.stop_session.call_args
+    assert kwargs["Id"] == "test-session"
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_session_not_found(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_session to raise EntityNotFoundException
+    mock_glue_client.exceptions.EntityNotFoundException = ClientError(
+        {"Error": {"Code": "EntityNotFoundException", "Message": "Session not found"}},
+        "get_session"
+    )
+    mock_glue_client.get_session.side_effect = mock_glue_client.exceptions.EntityNotFoundException
+
+    # Call the manage_aws_glue_sessions method with delete-session operation
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation="delete-session",
+        session_id="test-session"
+    )
+
+    # Verify the result indicates an error because the session was not found
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Session test-session not found" in result.content[0].text
+    assert result.session_id == "test-session"
+
+    # Verify that delete_session was NOT called
+    mock_glue_client.delete_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_session_invalid_operation(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Call the manage_aws_glue_sessions method with an invalid operation
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation="invalid-operation",
+        session_id="test-session"
+    )
+
+    # Verify the result indicates an error due to invalid operation
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Invalid operation: invalid-operation" in result.content[0].text
+    assert result.session_id == "test-session"
+
+
+# Tests for manage_aws_glue_statements method
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_run_statement_success(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the run_statement response
+    mock_glue_client.run_statement.return_value = {
+        "Id": 1
+    }
+
+    # Call the manage_aws_glue_statements method with run-statement operation
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx,
+        operation="run-statement",
+        session_id="test-session",
+        code="df = spark.read.csv('s3://bucket/data.csv')\ndf.show(5)"
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully ran statement in session test-session" in result.content[0].text
+    assert result.session_id == "test-session"
+    assert result.statement_id == 1
+
+    # Verify that run_statement was called with the correct parameters
+    mock_glue_client.run_statement.assert_called_once()
+    args, kwargs = mock_glue_client.run_statement.call_args
+    assert kwargs["SessionId"] == "test-session"
+    assert kwargs["Code"] == "df = spark.read.csv('s3://bucket/data.csv')\ndf.show(5)"
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_run_statement_no_write_access(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server without write access
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=False)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Call the manage_aws_glue_statements method with run-statement operation
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx,
+        operation="run-statement",
+        session_id="test-session",
+        code="df = spark.read.csv('s3://bucket/data.csv')\ndf.show(5)"
+    )
+
+    # Verify the result indicates an error due to no write access
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Operation run-statement is not allowed without write access" in result.content[0].text
+    assert result.session_id == ""
+
+    # Verify that run_statement was NOT called
+    mock_glue_client.run_statement.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_cancel_statement_success(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Call the manage_aws_glue_statements method with cancel-statement operation
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx,
+        operation="cancel-statement",
+        session_id="test-session",
+        statement_id=1
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully canceled statement 1 in session test-session" in result.content[0].text
+    assert result.session_id == "test-session"
+    assert result.statement_id == 1
+
+    # Verify that cancel_statement was called with the correct parameters
+    mock_glue_client.cancel_statement.assert_called_once()
+    args, kwargs = mock_glue_client.cancel_statement.call_args
+    assert kwargs["SessionId"] == "test-session"
+    assert kwargs["Id"] == 1
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_get_statement_success(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_statement response
+    mock_statement_details = {
+        "Id": 1,
+        "Code": "df = spark.read.csv('s3://bucket/data.csv')\ndf.show(5)",
+        "State": "AVAILABLE",
+        "Output": {
+            "Status": "ok",
+            "Data": {"text/plain": "+---+----+\n|id |name|\n+---+----+\n|1  |Alice|\n|2  |Bob  |\n+---+----+"}
+        }
+    }
+    mock_glue_client.get_statement.return_value = {
+        "Statement": mock_statement_details
+    }
+
+    # Call the manage_aws_glue_statements method with get-statement operation
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx,
+        operation="get-statement",
+        session_id="test-session",
+        statement_id=1
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully retrieved statement 1 in session test-session" in result.content[0].text
+    assert result.session_id == "test-session"
+    assert result.statement_id == 1
+    assert result.statement == mock_statement_details
+
+    # Verify that get_statement was called with the correct parameters
+    mock_glue_client.get_statement.assert_called_once()
+    args, kwargs = mock_glue_client.get_statement.call_args
+    assert kwargs["SessionId"] == "test-session"
+    assert kwargs["Id"] == 1
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_list_statements_success(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the list_statements response
+    mock_glue_client.list_statements.return_value = {
+        "Statements": [
+            {
+                "Id": 1,
+                "State": "AVAILABLE"
+            },
+            {
+                "Id": 2,
+                "State": "RUNNING"
+            }
+        ],
+        "NextToken": "next-token"
+    }
+
+    # Call the manage_aws_glue_statements method with list-statements operation
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx,
+        operation="list-statements",
+        session_id="test-session",
+        max_results=10,
+        next_token="token"
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully retrieved statements for session test-session" in result.content[0].text
+    assert result.session_id == "test-session"
+    assert len(result.statements) == 2
+    assert result.statements[0]["Id"] == 1
+    assert result.statements[1]["Id"] == 2
+    assert result.next_token == "next-token"
+    assert result.count == 2
+
+    # Verify that list_statements was called with the correct parameters
+    mock_glue_client.list_statements.assert_called_once()
+    args, kwargs = mock_glue_client.list_statements.call_args
+    assert kwargs["SessionId"] == "test-session"
+    assert "MaxResults" in kwargs
+    assert "NextToken" in kwargs
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_statement_invalid_operation(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Call the manage_aws_glue_statements method with an invalid operation
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx,
+        operation="invalid-operation",
+        session_id="test-session",
+        statement_id=1
+    )
+
+    # Verify the result indicates an error due to invalid operation
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Invalid operation: invalid-operation" in result.content[0].text
+    assert result.session_id == "test-session"
+    assert result.statement_id == 1
+
+
+# Split the test_missing_required_parameters into individual tests for better isolation
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_missing_role_and_command_for_create_session(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Test missing role and command for create-session
+    # The handler checks for None values, not missing parameters
+    with pytest.raises(ValueError) as excinfo:
+        await handler.manage_aws_glue_sessions(
+            mock_ctx,
+            operation="create-session",
+            session_id="test-session",
+            role=None,
+            command=None
+        )
+    assert "role and command are required" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_missing_session_id_for_delete_session(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Test missing session_id for delete-session
+    with pytest.raises(ValueError) as excinfo:
+        await handler.manage_aws_glue_sessions(
+            mock_ctx,
+            operation="delete-session",
+            session_id=None
+        )
+    assert "session_id is required" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_missing_session_id_for_get_session(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Test missing session_id for get-session
+    with pytest.raises(ValueError) as excinfo:
+        await handler.manage_aws_glue_sessions(
+            mock_ctx,
+            operation="get-session",
+            session_id=None
+        )
+    assert "session_id is required" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_missing_session_id_for_stop_session(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Test missing session_id for stop-session
+    with pytest.raises(ValueError) as excinfo:
+        await handler.manage_aws_glue_sessions(
+            mock_ctx,
+            operation="stop-session",
+            session_id=None
+        )
+    assert "session_id is required" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_missing_code_for_run_statement(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Test missing code for run-statement
+    with pytest.raises(ValueError) as excinfo:
+        await handler.manage_aws_glue_statements(
+            mock_ctx,
+            operation="run-statement",
+            session_id="test-session",
+            code=None
+        )
+    assert "code is required" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_missing_statement_id_for_cancel_statement(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Test missing statement_id for cancel-statement
+    with pytest.raises(ValueError) as excinfo:
+        await handler.manage_aws_glue_statements(
+            mock_ctx,
+            operation="cancel-statement",
+            session_id="test-session",
+            statement_id=None
+        )
+    assert "statement_id is required" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_missing_statement_id_for_get_statement(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Interactive Sessions handler with the mock MCP server
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Test missing statement_id for get-statement
+    with pytest.raises(ValueError) as excinfo:
+        await handler.manage_aws_glue_statements(
+            mock_ctx,
+            operation="get-statement",
+            session_id="test-session",
+            statement_id=None
+        )
+    assert "statement_id is required" in str(excinfo.value)

--- a/src/dataprocessing-mcp-server/tests/handlers/glue/test_glue_workflows_handler.py
+++ b/src/dataprocessing-mcp-server/tests/handlers/glue/test_glue_workflows_handler.py
@@ -1,0 +1,1014 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+# ruff: noqa: D101, D102, D103
+"""Tests for the Glue Workflows and Triggers handler."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from botocore.exceptions import ClientError
+from mcp.server.fastmcp import Context
+from awslabs.dataprocessing_mcp_server.handlers.glue.glue_worklows_handler import GlueWorkflowAndTriggerHandler
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_glue_workflow_handler_initialization(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+
+    # Verify that create_boto3_client was called with 'glue'
+    mock_create_client.assert_called_once_with("glue")
+
+    # Verify that all tools were registered
+    assert mock_mcp.tool.call_count == 2
+
+    # Get all call args
+    call_args_list = mock_mcp.tool.call_args_list
+
+    # Get all tool names that were registered
+    tool_names = [call_args[1]["name"] for call_args in call_args_list]
+
+    # Verify that all expected tools were registered
+    assert "manage_aws_glue_workflows" in tool_names
+    assert "manage_aws_glue_triggers" in tool_names
+
+
+# Tests for manage_aws_glue_workflows method
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id")
+async def test_create_workflow_success(mock_get_account_id, mock_get_region, mock_prepare_tags, mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Mock the resource tags
+    mock_prepare_tags.return_value = {"ManagedBy": "MCP"}
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the create_workflow response
+    mock_glue_client.create_workflow.return_value = {"Name": "test-workflow"}
+
+    # Call the manage_aws_glue_workflows method with create-workflow operation
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation="create-workflow",
+        workflow_name="test-workflow",
+        workflow_definition={
+            "Description": "Test workflow",
+            "DefaultRunProperties": {"ENV": "test"},
+            "MaxConcurrentRuns": 1
+        }
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully created workflow test-workflow" in result.content[0].text
+    assert result.workflow_name == "test-workflow"
+
+    # Verify that create_workflow was called with the correct parameters
+    mock_glue_client.create_workflow.assert_called_once()
+    args, kwargs = mock_glue_client.create_workflow.call_args
+    assert kwargs["Name"] == "test-workflow"
+    assert kwargs["Description"] == "Test workflow"
+    assert kwargs["DefaultRunProperties"] == {"ENV": "test"}
+    assert kwargs["MaxConcurrentRuns"] == 1
+    assert kwargs["Tags"] == {"ManagedBy": "MCP"}
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_create_workflow_no_write_access(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server without write access
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=False)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Call the manage_aws_glue_workflows method with create-workflow operation
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation="create-workflow",
+        workflow_name="test-workflow",
+        workflow_definition={
+            "Description": "Test workflow"
+        }
+    )
+
+    # Verify the result indicates an error due to no write access
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Operation create-workflow is not allowed without write access" in result.content[0].text
+    assert result.workflow_name == ""
+
+    # Verify that create_workflow was NOT called
+    mock_glue_client.create_workflow.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed")
+async def test_delete_workflow_success(mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Mock the region and account ID
+    mock_get_region.return_value = "us-east-1"
+    mock_get_account_id.return_value = "123456789012"
+    
+    # Mock the is_resource_mcp_managed to return True
+    mock_is_mcp_managed.return_value = True
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_workflow response
+    mock_glue_client.get_workflow.return_value = {
+        "Workflow": {
+            "Name": "test-workflow",
+            "Tags": {"ManagedBy": "MCP"}
+        }
+    }
+
+    # Call the manage_aws_glue_workflows method with delete-workflow operation
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation="delete-workflow",
+        workflow_name="test-workflow"
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully deleted workflow test-workflow" in result.content[0].text
+    assert result.workflow_name == "test-workflow"
+
+    # Verify that delete_workflow was called with the correct parameters
+    mock_glue_client.delete_workflow.assert_called_once_with(Name="test-workflow")
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed")
+async def test_delete_workflow_not_mcp_managed(mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Mock the region and account ID
+    mock_get_region.return_value = "us-east-1"
+    mock_get_account_id.return_value = "123456789012"
+    
+    # Mock the is_resource_mcp_managed to return False
+    mock_is_mcp_managed.return_value = False
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_workflow response
+    mock_glue_client.get_workflow.return_value = {
+        "Workflow": {
+            "Name": "test-workflow",
+            "Tags": {}  # No MCP tags
+        }
+    }
+
+    # Call the manage_aws_glue_workflows method with delete-workflow operation
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation="delete-workflow",
+        workflow_name="test-workflow"
+    )
+
+    # Verify the result indicates an error because the workflow is not MCP managed
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Cannot delete workflow test-workflow - it is not managed by the MCP server" in result.content[0].text
+    assert result.workflow_name == "test-workflow"
+
+    # Verify that delete_workflow was NOT called
+    mock_glue_client.delete_workflow.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_get_workflow_success(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_workflow response
+    mock_workflow_details = {
+        "Name": "test-workflow",
+        "Description": "Test workflow",
+        "CreatedOn": "2023-01-01T00:00:00Z"
+    }
+    mock_glue_client.get_workflow.return_value = {
+        "Workflow": mock_workflow_details
+    }
+
+    # Call the manage_aws_glue_workflows method with get-workflow operation
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation="get-workflow",
+        workflow_name="test-workflow"
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully retrieved workflow test-workflow" in result.content[0].text
+    assert result.workflow_name == "test-workflow"
+    assert result.workflow_details == mock_workflow_details
+
+    # Verify that get_workflow was called with the correct parameters
+    mock_glue_client.get_workflow.assert_called_once_with(Name="test-workflow")
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_get_workflow_with_include_graph(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_workflow response
+    mock_workflow_details = {
+        "Name": "test-workflow",
+        "Description": "Test workflow",
+        "CreatedOn": "2023-01-01T00:00:00Z",
+        "Graph": {
+            "Nodes": [{"Type": "JOB", "Name": "test-job"}],
+            "Edges": []
+        }
+    }
+    mock_glue_client.get_workflow.return_value = {
+        "Workflow": mock_workflow_details
+    }
+
+    # Call the manage_aws_glue_workflows method with get-workflow operation and include_graph
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation="get-workflow",
+        workflow_name="test-workflow",
+        workflow_definition={"include_graph": True}
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully retrieved workflow test-workflow" in result.content[0].text
+    assert result.workflow_name == "test-workflow"
+    assert result.workflow_details == mock_workflow_details
+
+    # Verify that get_workflow was called with the correct parameters
+    mock_glue_client.get_workflow.assert_called_once_with(Name="test-workflow", IncludeGraph=True)
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_list_workflows_success(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the list_workflows response - AWS API returns workflow names as strings
+    mock_glue_client.list_workflows.return_value = {
+        "Workflows": ["workflow1", "workflow2"],
+        "NextToken": "next-token"
+    }
+
+    # Call the manage_aws_glue_workflows method with list-workflows operation
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation="list-workflows",
+        max_results=10,
+        next_token="token"
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully retrieved workflows" in result.content[0].text
+    assert len(result.workflows) == 2
+    assert result.workflows[0]["Name"] == "workflow1"
+    assert result.workflows[1]["Name"] == "workflow2"
+    assert result.next_token == "next-token"
+
+    # Verify that list_workflows was called with the correct parameters
+    mock_glue_client.list_workflows.assert_called_once_with(MaxResults=10, NextToken="token")
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed")
+async def test_start_workflow_run_success(mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Mock the region and account ID
+    mock_get_region.return_value = "us-east-1"
+    mock_get_account_id.return_value = "123456789012"
+    
+    # Mock the is_resource_mcp_managed to return True
+    mock_is_mcp_managed.return_value = True
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_workflow response
+    mock_glue_client.get_workflow.return_value = {
+        "Workflow": {
+            "Name": "test-workflow",
+            "Tags": {"ManagedBy": "MCP"}
+        }
+    }
+
+    # Mock the start_workflow_run response
+    mock_glue_client.start_workflow_run.return_value = {
+        "RunId": "run-123"
+    }
+
+    # Call the manage_aws_glue_workflows method with start-workflow-run operation
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation="start-workflow-run",
+        workflow_name="test-workflow",
+        workflow_definition={"run_properties": {"ENV": "test"}}
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully started workflow run for test-workflow" in result.content[0].text
+    assert result.workflow_name == "test-workflow"
+    assert result.run_id == "run-123"
+
+    # Verify that start_workflow_run was called with the correct parameters
+    mock_glue_client.start_workflow_run.assert_called_once_with(
+        Name="test-workflow",
+        RunProperties={"ENV": "test"}
+    )
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_invalid_operation(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Call the manage_aws_glue_workflows method with an invalid operation
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation="invalid-operation",
+        workflow_name="test-workflow"
+    )
+
+    # Verify the result indicates an error due to invalid operation
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Invalid operation: invalid-operation" in result.content[0].text
+    assert result.workflow_name == "test-workflow"
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_workflow_not_found(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_workflow to raise EntityNotFoundException
+    mock_glue_client.exceptions.EntityNotFoundException = ClientError(
+        {"Error": {"Code": "EntityNotFoundException", "Message": "Workflow not found"}},
+        "get_workflow"
+    )
+    mock_glue_client.get_workflow.side_effect = mock_glue_client.exceptions.EntityNotFoundException
+
+    # Call the manage_aws_glue_workflows method with delete-workflow operation
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation="delete-workflow",
+        workflow_name="test-workflow"
+    )
+
+    # Verify the result indicates an error because the workflow was not found
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Workflow test-workflow not found" in result.content[0].text
+    assert result.workflow_name == "test-workflow"
+
+    # Verify that delete_workflow was NOT called
+    mock_glue_client.delete_workflow.assert_not_called()
+
+
+# Tests for manage_aws_glue_triggers method
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags")
+async def test_create_trigger_success(mock_prepare_tags, mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Mock the resource tags
+    mock_prepare_tags.return_value = {"ManagedBy": "MCP"}
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the create_trigger response
+    mock_glue_client.create_trigger.return_value = {"Name": "test-trigger"}
+
+    # Call the manage_aws_glue_triggers method with create-trigger operation
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation="create-trigger",
+        trigger_name="test-trigger",
+        trigger_definition={
+            "Type": "SCHEDULED",
+            "Schedule": "cron(0 12 * * ? *)",
+            "Actions": [{"JobName": "test-job"}],
+            "Description": "Test trigger",
+            "StartOnCreation": True
+        }
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully created trigger test-trigger" in result.content[0].text
+    assert result.trigger_name == "test-trigger"
+
+    # Verify that create_trigger was called with the correct parameters
+    mock_glue_client.create_trigger.assert_called_once()
+    args, kwargs = mock_glue_client.create_trigger.call_args
+    assert kwargs["Name"] == "test-trigger"
+    assert kwargs["Type"] == "SCHEDULED"
+    assert kwargs["Schedule"] == "cron(0 12 * * ? *)"
+    assert kwargs["Actions"] == [{"JobName": "test-job"}]
+    assert kwargs["Description"] == "Test trigger"
+    assert kwargs["StartOnCreation"] == True
+    assert kwargs["Tags"] == {"ManagedBy": "MCP"}
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_create_trigger_no_write_access(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server without write access
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=False)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Call the manage_aws_glue_triggers method with create-trigger operation
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation="create-trigger",
+        trigger_name="test-trigger",
+        trigger_definition={
+            "Type": "SCHEDULED",
+            "Actions": [{"JobName": "test-job"}]
+        }
+    )
+
+    # Verify the result indicates an error due to no write access
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Operation create-trigger is not allowed without write access" in result.content[0].text
+    assert result.trigger_name == ""
+
+    # Verify that create_trigger was NOT called
+    mock_glue_client.create_trigger.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed")
+async def test_delete_trigger_success(mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Mock the region and account ID
+    mock_get_region.return_value = "us-east-1"
+    mock_get_account_id.return_value = "123456789012"
+    
+    # Mock the is_resource_mcp_managed to return True
+    mock_is_mcp_managed.return_value = True
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_trigger response
+    mock_glue_client.get_trigger.return_value = {
+        "Trigger": {
+            "Name": "test-trigger",
+            "Tags": {"ManagedBy": "MCP"}
+        }
+    }
+
+    # Call the manage_aws_glue_triggers method with delete-trigger operation
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation="delete-trigger",
+        trigger_name="test-trigger"
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully deleted trigger test-trigger" in result.content[0].text
+    assert result.trigger_name == "test-trigger"
+
+    # Verify that delete_trigger was called with the correct parameters
+    mock_glue_client.delete_trigger.assert_called_once_with(Name="test-trigger")
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed")
+async def test_delete_trigger_not_mcp_managed(mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Mock the region and account ID
+    mock_get_region.return_value = "us-east-1"
+    mock_get_account_id.return_value = "123456789012"
+    
+    # Mock the is_resource_mcp_managed to return False
+    mock_is_mcp_managed.return_value = False
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_trigger response
+    mock_glue_client.get_trigger.return_value = {
+        "Trigger": {
+            "Name": "test-trigger",
+            "Tags": {}  # No MCP tags
+        }
+    }
+
+    # Call the manage_aws_glue_triggers method with delete-trigger operation
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation="delete-trigger",
+        trigger_name="test-trigger"
+    )
+
+    # Verify the result indicates an error because the trigger is not MCP managed
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Cannot delete trigger test-trigger - it is not managed by the MCP server" in result.content[0].text
+    assert result.trigger_name == "test-trigger"
+
+    # Verify that delete_trigger was NOT called
+    mock_glue_client.delete_trigger.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_get_trigger_success(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_trigger response
+    mock_trigger_details = {
+        "Name": "test-trigger",
+        "Type": "SCHEDULED",
+        "Schedule": "cron(0 12 * * ? *)",
+        "Actions": [{"JobName": "test-job"}],
+        "Description": "Test trigger"
+    }
+    mock_glue_client.get_trigger.return_value = {
+        "Trigger": mock_trigger_details
+    }
+
+    # Call the manage_aws_glue_triggers method with get-trigger operation
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation="get-trigger",
+        trigger_name="test-trigger"
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully retrieved trigger test-trigger" in result.content[0].text
+    assert result.trigger_name == "test-trigger"
+    assert result.trigger_details == mock_trigger_details
+
+    # Verify that get_trigger was called with the correct parameters
+    mock_glue_client.get_trigger.assert_called_once_with(Name="test-trigger")
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_get_triggers_success(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_triggers response
+    mock_glue_client.get_triggers.return_value = {
+        "Triggers": [
+            {
+                "Name": "trigger1",
+                "Type": "SCHEDULED"
+            },
+            {
+                "Name": "trigger2",
+                "Type": "CONDITIONAL"
+            }
+        ],
+        "NextToken": "next-token"
+    }
+
+    # Call the manage_aws_glue_triggers method with get-triggers operation
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation="get-triggers",
+        max_results=10,
+        next_token="token"
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully retrieved triggers" in result.content[0].text
+    assert len(result.triggers) == 2
+    assert result.triggers[0]["Name"] == "trigger1"
+    assert result.triggers[1]["Name"] == "trigger2"
+    assert result.next_token == "next-token"
+
+    # Verify that get_triggers was called with the correct parameters
+    mock_glue_client.get_triggers.assert_called_once_with(MaxResults=10, NextToken="token")
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed")
+async def test_start_trigger_success(mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Mock the region and account ID
+    mock_get_region.return_value = "us-east-1"
+    mock_get_account_id.return_value = "123456789012"
+    
+    # Mock the is_resource_mcp_managed to return True
+    mock_is_mcp_managed.return_value = True
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_trigger response
+    mock_glue_client.get_trigger.return_value = {
+        "Trigger": {
+            "Name": "test-trigger",
+            "Tags": {"ManagedBy": "MCP"}
+        }
+    }
+
+    # Call the manage_aws_glue_triggers method with start-trigger operation
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation="start-trigger",
+        trigger_name="test-trigger"
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully started trigger test-trigger" in result.content[0].text
+    assert result.trigger_name == "test-trigger"
+
+    # Verify that start_trigger was called with the correct parameters
+    mock_glue_client.start_trigger.assert_called_once_with(Name="test-trigger")
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id")
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed")
+async def test_stop_trigger_success(mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Mock the region and account ID
+    mock_get_region.return_value = "us-east-1"
+    mock_get_account_id.return_value = "123456789012"
+    
+    # Mock the is_resource_mcp_managed to return True
+    mock_is_mcp_managed.return_value = True
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_trigger response
+    mock_glue_client.get_trigger.return_value = {
+        "Trigger": {
+            "Name": "test-trigger",
+            "Tags": {"ManagedBy": "MCP"}
+        }
+    }
+
+    # Call the manage_aws_glue_triggers method with stop-trigger operation
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation="stop-trigger",
+        trigger_name="test-trigger"
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Successfully stopped trigger test-trigger" in result.content[0].text
+    assert result.trigger_name == "test-trigger"
+
+    # Verify that stop_trigger was called with the correct parameters
+    mock_glue_client.stop_trigger.assert_called_once_with(Name="test-trigger")
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_trigger_invalid_operation(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server with write access
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Call the manage_aws_glue_triggers method with an invalid operation
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation="invalid-operation",
+        trigger_name="test-trigger"
+    )
+
+    # Verify the result indicates an error due to invalid operation
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Invalid operation: invalid-operation" in result.content[0].text
+    assert result.trigger_name == "test-trigger"
+
+
+@pytest.mark.asyncio
+@patch("awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client")
+async def test_trigger_not_found(mock_create_client):
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_trigger to raise EntityNotFoundException
+    mock_glue_client.exceptions.EntityNotFoundException = ClientError(
+        {"Error": {"Code": "EntityNotFoundException", "Message": "Trigger not found"}},
+        "get_trigger"
+    )
+    mock_glue_client.get_trigger.side_effect = mock_glue_client.exceptions.EntityNotFoundException
+
+    # Call the manage_aws_glue_triggers method with delete-trigger operation
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation="delete-trigger",
+        trigger_name="test-trigger"
+    )
+
+    # Verify the result indicates an error because the trigger was not found
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Trigger test-trigger not found" in result.content[0].text
+    assert result.trigger_name == "test-trigger"
+
+    # Verify that delete_trigger was NOT called
+    mock_glue_client.delete_trigger.assert_not_called()

--- a/src/dataprocessing-mcp-server/tests/models/test_glue_models.py
+++ b/src/dataprocessing-mcp-server/tests/models/test_glue_models.py
@@ -55,7 +55,7 @@ class TestWorkflowResponses:
         )
         assert response.isError is False
         assert response.workflow_name == "test-workflow"
-        assert response.operation == "create"
+        assert response.operation == "create-workflow"
 
     def test_get_workflow_response(self):
         response = GetWorkflowResponse(
@@ -67,7 +67,7 @@ class TestWorkflowResponses:
         assert response.isError is False
         assert response.workflow_name == "test-workflow"
         assert response.workflow_details == sample_dict
-        assert response.operation == "get"
+        assert response.operation == "get-workflow"
 
 
 class TestTriggerResponses:
@@ -79,7 +79,7 @@ class TestTriggerResponses:
         )
         assert response.isError is False
         assert response.trigger_name == "test-trigger"
-        assert response.operation == "create"
+        assert response.operation == "create-trigger"
 
     def test_get_triggers_response(self):
         response = GetTriggersResponse(
@@ -91,7 +91,7 @@ class TestTriggerResponses:
         assert response.isError is False
         assert response.triggers == sample_list
         assert response.next_token == "next-page"
-        assert response.operation == "list"
+        assert response.operation == "get-triggers"
 
 
 class TestSessionResponses:
@@ -105,7 +105,7 @@ class TestSessionResponses:
         assert response.isError is False
         assert response.session_id == "session-123"
         assert response.session == sample_dict
-        assert response.operation == "create"
+        assert response.operation == "create-session"
 
     def test_list_sessions_response(self):
         response = ListSessionsResponse(
@@ -121,7 +121,7 @@ class TestSessionResponses:
         assert response.count == 2
         assert response.ids == ["session-1", "session-2"]
         assert response.next_token == "next-page"
-        assert response.operation == "list"
+        assert response.operation == "list-sessions"
 
 
 class TestSecurityResponses:
@@ -219,7 +219,7 @@ def test_error_responses():
 def test_optional_fields():
     """Test responses with optional fields"""
     # Test response with optional next_token
-    list_response = GetWorkflowsResponse(
+    list_response = ListWorkflowsResponse(
         isError=False,
         content=sample_text_content,
         workflows=sample_list,

--- a/src/dataprocessing-mcp-server/tests/models/test_interactive_sessions_models.py
+++ b/src/dataprocessing-mcp-server/tests/models/test_interactive_sessions_models.py
@@ -1,0 +1,492 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+"""Tests for the Glue Interactive Sessions models."""
+
+import pytest
+from awslabs.dataprocessing_mcp_server.models.glue_models import (
+    # Session response models
+    CreateSessionResponse,
+    DeleteSessionResponse,
+    GetSessionResponse,
+    ListSessionsResponse,
+    StopSessionResponse,
+    # Statement response models
+    RunStatementResponse,
+    CancelStatementResponse,
+    GetStatementResponse,
+    ListStatementsResponse,
+)
+from mcp.types import TextContent
+from pydantic import ValidationError
+
+
+class TestSessionResponseModels:
+    """Tests for the session response models."""
+
+    def test_create_session_response(self):
+        """Test creating a CreateSessionResponse."""
+        session_details = {
+            "Id": "test-session",
+            "Status": "PROVISIONING",
+            "Command": {"Name": "glueetl", "PythonVersion": "3"},
+            "GlueVersion": "3.0",
+        }
+        
+        response = CreateSessionResponse(
+            isError=False,
+            session_id="test-session",
+            session=session_details,
+            content=[TextContent(type="text", text="Successfully created session")],
+        )
+        
+        assert response.isError is False
+        assert response.session_id == "test-session"
+        assert response.session == session_details
+        assert response.operation == "create-session"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully created session"
+
+    def test_create_session_response_with_error(self):
+        """Test creating a CreateSessionResponse with error."""
+        response = CreateSessionResponse(
+            isError=True,
+            session_id="",
+            session=None,
+            content=[TextContent(type="text", text="Failed to create session")],
+        )
+        
+        assert response.isError is True
+        assert response.session_id == ""
+        assert response.session is None
+        assert response.operation == "create-session"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to create session"
+
+    def test_delete_session_response(self):
+        """Test creating a DeleteSessionResponse."""
+        response = DeleteSessionResponse(
+            isError=False,
+            session_id="test-session",
+            content=[TextContent(type="text", text="Successfully deleted session")],
+        )
+        
+        assert response.isError is False
+        assert response.session_id == "test-session"
+        assert response.operation == "delete-session"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully deleted session"
+
+    def test_delete_session_response_with_error(self):
+        """Test creating a DeleteSessionResponse with error."""
+        response = DeleteSessionResponse(
+            isError=True,
+            session_id="test-session",
+            content=[TextContent(type="text", text="Failed to delete session")],
+        )
+        
+        assert response.isError is True
+        assert response.session_id == "test-session"
+        assert response.operation == "delete-session"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to delete session"
+
+    def test_get_session_response(self):
+        """Test creating a GetSessionResponse."""
+        session_details = {
+            "Id": "test-session",
+            "Status": "READY",
+            "Command": {"Name": "glueetl", "PythonVersion": "3"},
+            "GlueVersion": "3.0",
+            "CreatedOn": "2023-01-01T00:00:00Z",
+        }
+        
+        response = GetSessionResponse(
+            isError=False,
+            session_id="test-session",
+            session=session_details,
+            content=[TextContent(type="text", text="Successfully retrieved session")],
+        )
+        
+        assert response.isError is False
+        assert response.session_id == "test-session"
+        assert response.session == session_details
+        assert response.operation == "get-session"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully retrieved session"
+
+    def test_get_session_response_with_error(self):
+        """Test creating a GetSessionResponse with error."""
+        response = GetSessionResponse(
+            isError=True,
+            session_id="test-session",
+            session={},
+            content=[TextContent(type="text", text="Failed to retrieve session")],
+        )
+        
+        assert response.isError is True
+        assert response.session_id == "test-session"
+        assert response.session == {}
+        assert response.operation == "get-session"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to retrieve session"
+
+    def test_list_sessions_response(self):
+        """Test creating a ListSessionsResponse."""
+        sessions = [
+            {
+                "Id": "session1",
+                "Status": "READY",
+                "Command": {"Name": "glueetl", "PythonVersion": "3"},
+            },
+            {
+                "Id": "session2",
+                "Status": "PROVISIONING",
+                "Command": {"Name": "glueetl", "PythonVersion": "3"},
+            },
+        ]
+        
+        response = ListSessionsResponse(
+            isError=False,
+            sessions=sessions,
+            ids=["session1", "session2"],
+            count=2,
+            next_token="next-token",
+            content=[TextContent(type="text", text="Successfully listed sessions")],
+        )
+        
+        assert response.isError is False
+        assert len(response.sessions) == 2
+        assert response.sessions[0]["Id"] == "session1"
+        assert response.sessions[1]["Id"] == "session2"
+        assert response.ids == ["session1", "session2"]
+        assert response.count == 2
+        assert response.next_token == "next-token"
+        assert response.operation == "list-sessions"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully listed sessions"
+
+    def test_list_sessions_response_with_error(self):
+        """Test creating a ListSessionsResponse with error."""
+        response = ListSessionsResponse(
+            isError=True,
+            sessions=[],
+            count=0,
+            content=[TextContent(type="text", text="Failed to list sessions")],
+        )
+        
+        assert response.isError is True
+        assert len(response.sessions) == 0
+        assert response.count == 0
+        assert response.next_token is None  # Default value
+        assert response.operation == "list-sessions"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to list sessions"
+
+    def test_stop_session_response(self):
+        """Test creating a StopSessionResponse."""
+        response = StopSessionResponse(
+            isError=False,
+            session_id="test-session",
+            content=[TextContent(type="text", text="Successfully stopped session")],
+        )
+        
+        assert response.isError is False
+        assert response.session_id == "test-session"
+        assert response.operation == "stop-session"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully stopped session"
+
+    def test_stop_session_response_with_error(self):
+        """Test creating a StopSessionResponse with error."""
+        response = StopSessionResponse(
+            isError=True,
+            session_id="test-session",
+            content=[TextContent(type="text", text="Failed to stop session")],
+        )
+        
+        assert response.isError is True
+        assert response.session_id == "test-session"
+        assert response.operation == "stop-session"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to stop session"
+
+
+class TestStatementResponseModels:
+    """Tests for the statement response models."""
+
+    def test_run_statement_response(self):
+        """Test creating a RunStatementResponse."""
+        response = RunStatementResponse(
+            isError=False,
+            session_id="test-session",
+            statement_id=1,
+            content=[TextContent(type="text", text="Successfully ran statement")],
+        )
+        
+        assert response.isError is False
+        assert response.session_id == "test-session"
+        assert response.statement_id == 1
+        assert response.operation == "run-statement"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully ran statement"
+
+    def test_run_statement_response_with_error(self):
+        """Test creating a RunStatementResponse with error."""
+        response = RunStatementResponse(
+            isError=True,
+            session_id="test-session",
+            statement_id=0,
+            content=[TextContent(type="text", text="Failed to run statement")],
+        )
+        
+        assert response.isError is True
+        assert response.session_id == "test-session"
+        assert response.statement_id == 0
+        assert response.operation == "run-statement"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to run statement"
+
+    def test_cancel_statement_response(self):
+        """Test creating a CancelStatementResponse."""
+        response = CancelStatementResponse(
+            isError=False,
+            session_id="test-session",
+            statement_id=1,
+            content=[TextContent(type="text", text="Successfully canceled statement")],
+        )
+        
+        assert response.isError is False
+        assert response.session_id == "test-session"
+        assert response.statement_id == 1
+        assert response.operation == "cancel-statement"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully canceled statement"
+
+    def test_cancel_statement_response_with_error(self):
+        """Test creating a CancelStatementResponse with error."""
+        response = CancelStatementResponse(
+            isError=True,
+            session_id="test-session",
+            statement_id=1,
+            content=[TextContent(type="text", text="Failed to cancel statement")],
+        )
+        
+        assert response.isError is True
+        assert response.session_id == "test-session"
+        assert response.statement_id == 1
+        assert response.operation == "cancel-statement"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to cancel statement"
+
+    def test_get_statement_response(self):
+        """Test creating a GetStatementResponse."""
+        statement_details = {
+            "Id": 1,
+            "Code": "df = spark.read.csv('s3://bucket/data.csv')\ndf.show(5)",
+            "State": "AVAILABLE",
+            "Output": {
+                "Status": "ok",
+                "Data": {"text/plain": "+---+----+\n|id |name|\n+---+----+\n|1  |Alice|\n|2  |Bob  |\n+---+----+"}
+            }
+        }
+        
+        response = GetStatementResponse(
+            isError=False,
+            session_id="test-session",
+            statement_id=1,
+            statement=statement_details,
+            content=[TextContent(type="text", text="Successfully retrieved statement")],
+        )
+        
+        assert response.isError is False
+        assert response.session_id == "test-session"
+        assert response.statement_id == 1
+        assert response.statement == statement_details
+        assert response.operation == "get-statement"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully retrieved statement"
+
+    def test_get_statement_response_with_error(self):
+        """Test creating a GetStatementResponse with error."""
+        response = GetStatementResponse(
+            isError=True,
+            session_id="test-session",
+            statement_id=1,
+            statement={},
+            content=[TextContent(type="text", text="Failed to retrieve statement")],
+        )
+        
+        assert response.isError is True
+        assert response.session_id == "test-session"
+        assert response.statement_id == 1
+        assert response.statement == {}
+        assert response.operation == "get-statement"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to retrieve statement"
+
+    def test_list_statements_response(self):
+        """Test creating a ListStatementsResponse."""
+        statements = [
+            {
+                "Id": 1,
+                "State": "AVAILABLE",
+                "Code": "df = spark.read.csv('s3://bucket/data.csv')"
+            },
+            {
+                "Id": 2,
+                "State": "RUNNING",
+                "Code": "df.show(5)"
+            }
+        ]
+        
+        response = ListStatementsResponse(
+            isError=False,
+            session_id="test-session",
+            statements=statements,
+            count=2,
+            next_token="next-token",
+            content=[TextContent(type="text", text="Successfully listed statements")],
+        )
+        
+        assert response.isError is False
+        assert response.session_id == "test-session"
+        assert len(response.statements) == 2
+        assert response.statements[0]["Id"] == 1
+        assert response.statements[1]["Id"] == 2
+        assert response.count == 2
+        assert response.next_token == "next-token"
+        assert response.operation == "list-statements"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully listed statements"
+
+    def test_list_statements_response_with_error(self):
+        """Test creating a ListStatementsResponse with error."""
+        response = ListStatementsResponse(
+            isError=True,
+            session_id="test-session",
+            statements=[],
+            count=0,
+            content=[TextContent(type="text", text="Failed to list statements")],
+        )
+        
+        assert response.isError is True
+        assert response.session_id == "test-session"
+        assert len(response.statements) == 0
+        assert response.count == 0
+        assert response.next_token is None  # Default value
+        assert response.operation == "list-statements"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to list statements"
+
+
+class TestValidationErrors:
+    """Tests for validation errors in the models."""
+
+    def test_create_session_response_missing_required_fields(self):
+        """Test that creating a CreateSessionResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            CreateSessionResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing session_id")]
+            )
+
+    def test_delete_session_response_missing_required_fields(self):
+        """Test that creating a DeleteSessionResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            DeleteSessionResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing session_id")]
+            )
+
+    def test_get_session_response_missing_required_fields(self):
+        """Test that creating a GetSessionResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            GetSessionResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing session_id")]
+            )
+
+    def test_list_sessions_response_missing_required_fields(self):
+        """Test that creating a ListSessionsResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            ListSessionsResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing sessions and count")]
+            )
+
+    def test_stop_session_response_missing_required_fields(self):
+        """Test that creating a StopSessionResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            StopSessionResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing session_id")]
+            )
+
+    def test_run_statement_response_missing_required_fields(self):
+        """Test that creating a RunStatementResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            RunStatementResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing session_id and statement_id")]
+            )
+
+        with pytest.raises(ValidationError):
+            RunStatementResponse(
+                isError=False,
+                session_id="test-session",
+                content=[TextContent(type="text", text="Missing statement_id")]
+            )
+
+    def test_cancel_statement_response_missing_required_fields(self):
+        """Test that creating a CancelStatementResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            CancelStatementResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing session_id and statement_id")]
+            )
+
+        with pytest.raises(ValidationError):
+            CancelStatementResponse(
+                isError=False,
+                session_id="test-session",
+                content=[TextContent(type="text", text="Missing statement_id")]
+            )
+
+    def test_get_statement_response_missing_required_fields(self):
+        """Test that creating a GetStatementResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            GetStatementResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing session_id and statement_id")]
+            )
+
+        with pytest.raises(ValidationError):
+            GetStatementResponse(
+                isError=False,
+                session_id="test-session",
+                content=[TextContent(type="text", text="Missing statement_id")]
+            )
+
+    def test_list_statements_response_missing_required_fields(self):
+        """Test that creating a ListStatementsResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            ListStatementsResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing session_id, statements, and count")]
+            )
+
+        with pytest.raises(ValidationError):
+            ListStatementsResponse(
+                isError=False,
+                session_id="test-session",
+                content=[TextContent(type="text", text="Missing statements and count")]
+            )

--- a/src/dataprocessing-mcp-server/tests/models/test_workflows_models.py
+++ b/src/dataprocessing-mcp-server/tests/models/test_workflows_models.py
@@ -1,0 +1,533 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+"""Tests for the Glue Workflows models."""
+
+import pytest
+from awslabs.dataprocessing_mcp_server.models.glue_models import (
+    # Workflow response models
+    CreateWorkflowResponse,
+    DeleteWorkflowResponse,
+    GetWorkflowResponse,
+    ListWorkflowsResponse,
+    StartWorkflowRunResponse,
+    # Trigger response models
+    CreateTriggerResponse,
+    DeleteTriggerResponse,
+    GetTriggerResponse,
+    GetTriggersResponse,
+    StartTriggerResponse,
+    StopTriggerResponse,
+)
+from mcp.types import TextContent
+from pydantic import ValidationError
+
+
+class TestWorkflowResponseModels:
+    """Tests for the workflow response models."""
+
+    def test_create_workflow_response(self):
+        """Test creating a CreateWorkflowResponse."""
+        response = CreateWorkflowResponse(
+            isError=False,
+            workflow_name="test-workflow",
+            content=[TextContent(type="text", text="Successfully created workflow")],
+        )
+        
+        assert response.isError is False
+        assert response.workflow_name == "test-workflow"
+        assert response.operation == "create-workflow"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully created workflow"
+
+    def test_create_workflow_response_with_error(self):
+        """Test creating a CreateWorkflowResponse with error."""
+        response = CreateWorkflowResponse(
+            isError=True,
+            workflow_name="test-workflow",
+            content=[TextContent(type="text", text="Failed to create workflow")],
+        )
+        
+        assert response.isError is True
+        assert response.workflow_name == "test-workflow"
+        assert response.operation == "create-workflow"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to create workflow"
+
+    def test_delete_workflow_response(self):
+        """Test creating a DeleteWorkflowResponse."""
+        response = DeleteWorkflowResponse(
+            isError=False,
+            workflow_name="test-workflow",
+            content=[TextContent(type="text", text="Successfully deleted workflow")],
+        )
+        
+        assert response.isError is False
+        assert response.workflow_name == "test-workflow"
+        assert response.operation == "delete-workflow"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully deleted workflow"
+
+    def test_delete_workflow_response_with_error(self):
+        """Test creating a DeleteWorkflowResponse with error."""
+        response = DeleteWorkflowResponse(
+            isError=True,
+            workflow_name="test-workflow",
+            content=[TextContent(type="text", text="Failed to delete workflow")],
+        )
+        
+        assert response.isError is True
+        assert response.workflow_name == "test-workflow"
+        assert response.operation == "delete-workflow"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to delete workflow"
+
+    def test_get_workflow_response(self):
+        """Test creating a GetWorkflowResponse."""
+        workflow_details = {
+            "Name": "test-workflow",
+            "Description": "Test workflow",
+            "CreatedOn": "2023-01-01T00:00:00Z",
+            "LastModifiedOn": "2023-01-02T00:00:00Z",
+            "LastRun": {
+                "Name": "test-run",
+                "StartedOn": "2023-01-03T00:00:00Z",
+                "CompletedOn": "2023-01-03T01:00:00Z",
+                "Status": "COMPLETED",
+            },
+        }
+        
+        response = GetWorkflowResponse(
+            isError=False,
+            workflow_name="test-workflow",
+            workflow_details=workflow_details,
+            content=[TextContent(type="text", text="Successfully retrieved workflow")],
+        )
+        
+        assert response.isError is False
+        assert response.workflow_name == "test-workflow"
+        assert response.workflow_details == workflow_details
+        assert response.operation == "get-workflow"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully retrieved workflow"
+
+    def test_get_workflow_response_with_error(self):
+        """Test creating a GetWorkflowResponse with error."""
+        response = GetWorkflowResponse(
+            isError=True,
+            workflow_name="test-workflow",
+            workflow_details={},
+            content=[TextContent(type="text", text="Failed to retrieve workflow")],
+        )
+        
+        assert response.isError is True
+        assert response.workflow_name == "test-workflow"
+        assert response.workflow_details == {}
+        assert response.operation == "get-workflow"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to retrieve workflow"
+
+    def test_list_workflows_response(self):
+        """Test creating a ListWorkflowsResponse."""
+        workflows = [
+            {
+                "Name": "workflow1",
+                "CreatedOn": "2023-01-01T00:00:00Z",
+            },
+            {
+                "Name": "workflow2",
+                "CreatedOn": "2023-01-02T00:00:00Z",
+            },
+        ]
+        
+        response = ListWorkflowsResponse(
+            isError=False,
+            workflows=workflows,
+            next_token="next-token",
+            content=[TextContent(type="text", text="Successfully retrieved workflows")],
+        )
+        
+        assert response.isError is False
+        assert len(response.workflows) == 2
+        assert response.workflows[0]["Name"] == "workflow1"
+        assert response.workflows[1]["Name"] == "workflow2"
+        assert response.next_token == "next-token"
+        assert response.operation == "list-workflows"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully retrieved workflows"
+
+    def test_list_workflows_response_with_error(self):
+        """Test creating a ListWorkflowsResponse with error."""
+        response = ListWorkflowsResponse(
+            isError=True,
+            workflows=[],
+            content=[TextContent(type="text", text="Failed to retrieve workflows")],
+        )
+        
+        assert response.isError is True
+        assert len(response.workflows) == 0
+        assert response.next_token is None  # Default value
+        assert response.operation == "list-workflows"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to retrieve workflows"
+
+    def test_start_workflow_run_response(self):
+        """Test creating a StartWorkflowRunResponse."""
+        response = StartWorkflowRunResponse(
+            isError=False,
+            workflow_name="test-workflow",
+            run_id="run-12345",
+            content=[TextContent(type="text", text="Successfully started workflow run")],
+        )
+        
+        assert response.isError is False
+        assert response.workflow_name == "test-workflow"
+        assert response.run_id == "run-12345"
+        assert response.operation == "start-workflow-run"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully started workflow run"
+
+    def test_start_workflow_run_response_with_error(self):
+        """Test creating a StartWorkflowRunResponse with error."""
+        response = StartWorkflowRunResponse(
+            isError=True,
+            workflow_name="test-workflow",
+            run_id="",
+            content=[TextContent(type="text", text="Failed to start workflow run")],
+        )
+        
+        assert response.isError is True
+        assert response.workflow_name == "test-workflow"
+        assert response.run_id == ""
+        assert response.operation == "start-workflow-run"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to start workflow run"
+
+
+class TestTriggerResponseModels:
+    """Tests for the trigger response models."""
+
+    def test_create_trigger_response(self):
+        """Test creating a CreateTriggerResponse."""
+        response = CreateTriggerResponse(
+            isError=False,
+            trigger_name="test-trigger",
+            content=[TextContent(type="text", text="Successfully created trigger")],
+        )
+        
+        assert response.isError is False
+        assert response.trigger_name == "test-trigger"
+        assert response.operation == "create-trigger"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully created trigger"
+
+    def test_create_trigger_response_with_error(self):
+        """Test creating a CreateTriggerResponse with error."""
+        response = CreateTriggerResponse(
+            isError=True,
+            trigger_name="test-trigger",
+            content=[TextContent(type="text", text="Failed to create trigger")],
+        )
+        
+        assert response.isError is True
+        assert response.trigger_name == "test-trigger"
+        assert response.operation == "create-trigger"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to create trigger"
+
+    def test_delete_trigger_response(self):
+        """Test creating a DeleteTriggerResponse."""
+        response = DeleteTriggerResponse(
+            isError=False,
+            trigger_name="test-trigger",
+            content=[TextContent(type="text", text="Successfully deleted trigger")],
+        )
+        
+        assert response.isError is False
+        assert response.trigger_name == "test-trigger"
+        assert response.operation == "delete-trigger"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully deleted trigger"
+
+    def test_delete_trigger_response_with_error(self):
+        """Test creating a DeleteTriggerResponse with error."""
+        response = DeleteTriggerResponse(
+            isError=True,
+            trigger_name="test-trigger",
+            content=[TextContent(type="text", text="Failed to delete trigger")],
+        )
+        
+        assert response.isError is True
+        assert response.trigger_name == "test-trigger"
+        assert response.operation == "delete-trigger"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to delete trigger"
+
+    def test_get_trigger_response(self):
+        """Test creating a GetTriggerResponse."""
+        trigger_details = {
+            "Name": "test-trigger",
+            "Type": "SCHEDULED",
+            "Schedule": "cron(0 0 * * ? *)",
+            "State": "CREATED",
+            "Actions": [
+                {
+                    "JobName": "test-job",
+                    "Arguments": {"--key": "value"},
+                }
+            ],
+            "CreatedOn": "2023-01-01T00:00:00Z",
+        }
+        
+        response = GetTriggerResponse(
+            isError=False,
+            trigger_name="test-trigger",
+            trigger_details=trigger_details,
+            content=[TextContent(type="text", text="Successfully retrieved trigger")],
+        )
+        
+        assert response.isError is False
+        assert response.trigger_name == "test-trigger"
+        assert response.trigger_details == trigger_details
+        assert response.operation == "get-trigger"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully retrieved trigger"
+
+    def test_get_trigger_response_with_error(self):
+        """Test creating a GetTriggerResponse with error."""
+        response = GetTriggerResponse(
+            isError=True,
+            trigger_name="test-trigger",
+            trigger_details={},
+            content=[TextContent(type="text", text="Failed to retrieve trigger")],
+        )
+        
+        assert response.isError is True
+        assert response.trigger_name == "test-trigger"
+        assert response.trigger_details == {}
+        assert response.operation == "get-trigger"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to retrieve trigger"
+
+    def test_get_triggers_response(self):
+        """Test creating a GetTriggersResponse."""
+        triggers = [
+            {
+                "Name": "trigger1",
+                "Type": "SCHEDULED",
+                "State": "CREATED",
+            },
+            {
+                "Name": "trigger2",
+                "Type": "CONDITIONAL",
+                "State": "ACTIVATED",
+            },
+        ]
+        
+        response = GetTriggersResponse(
+            isError=False,
+            triggers=triggers,
+            next_token="next-token",
+            content=[TextContent(type="text", text="Successfully retrieved triggers")],
+        )
+        
+        assert response.isError is False
+        assert len(response.triggers) == 2
+        assert response.triggers[0]["Name"] == "trigger1"
+        assert response.triggers[1]["Name"] == "trigger2"
+        assert response.next_token == "next-token"
+        assert response.operation == "get-triggers"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully retrieved triggers"
+
+    def test_get_triggers_response_with_error(self):
+        """Test creating a GetTriggersResponse with error."""
+        response = GetTriggersResponse(
+            isError=True,
+            triggers=[],
+            content=[TextContent(type="text", text="Failed to retrieve triggers")],
+        )
+        
+        assert response.isError is True
+        assert len(response.triggers) == 0
+        assert response.next_token is None  # Default value
+        assert response.operation == "get-triggers"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to retrieve triggers"
+
+    def test_start_trigger_response(self):
+        """Test creating a StartTriggerResponse."""
+        response = StartTriggerResponse(
+            isError=False,
+            trigger_name="test-trigger",
+            content=[TextContent(type="text", text="Successfully started trigger")],
+        )
+        
+        assert response.isError is False
+        assert response.trigger_name == "test-trigger"
+        assert response.operation == "start-trigger"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully started trigger"
+
+    def test_start_trigger_response_with_error(self):
+        """Test creating a StartTriggerResponse with error."""
+        response = StartTriggerResponse(
+            isError=True,
+            trigger_name="test-trigger",
+            content=[TextContent(type="text", text="Failed to start trigger")],
+        )
+        
+        assert response.isError is True
+        assert response.trigger_name == "test-trigger"
+        assert response.operation == "start-trigger"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to start trigger"
+
+    def test_stop_trigger_response(self):
+        """Test creating a StopTriggerResponse."""
+        response = StopTriggerResponse(
+            isError=False,
+            trigger_name="test-trigger",
+            content=[TextContent(type="text", text="Successfully stopped trigger")],
+        )
+        
+        assert response.isError is False
+        assert response.trigger_name == "test-trigger"
+        assert response.operation == "stop-trigger"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Successfully stopped trigger"
+
+    def test_stop_trigger_response_with_error(self):
+        """Test creating a StopTriggerResponse with error."""
+        response = StopTriggerResponse(
+            isError=True,
+            trigger_name="test-trigger",
+            content=[TextContent(type="text", text="Failed to stop trigger")],
+        )
+        
+        assert response.isError is True
+        assert response.trigger_name == "test-trigger"
+        assert response.operation == "stop-trigger"  # Default value
+        assert len(response.content) == 1
+        assert response.content[0].text == "Failed to stop trigger"
+
+
+class TestValidationErrors:
+    """Tests for validation errors in the models."""
+
+    def test_create_workflow_response_missing_required_fields(self):
+        """Test that creating a CreateWorkflowResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            CreateWorkflowResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing workflow_name")]
+            )
+
+    def test_delete_workflow_response_missing_required_fields(self):
+        """Test that creating a DeleteWorkflowResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            DeleteWorkflowResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing workflow_name")]
+            )
+
+    def test_get_workflow_response_missing_required_fields(self):
+        """Test that creating a GetWorkflowResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            GetWorkflowResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing workflow_name and workflow_details")]
+            )
+
+        with pytest.raises(ValidationError):
+            GetWorkflowResponse(
+                isError=False,
+                workflow_name="test-workflow",
+                content=[TextContent(type="text", text="Missing workflow_details")]
+            )
+
+    def test_list_workflows_response_missing_required_fields(self):
+        """Test that creating a ListWorkflowsResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            ListWorkflowsResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing workflows")]
+            )
+
+    def test_start_workflow_run_response_missing_required_fields(self):
+        """Test that creating a StartWorkflowRunResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            StartWorkflowRunResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing workflow_name and run_id")]
+            )
+
+        with pytest.raises(ValidationError):
+            StartWorkflowRunResponse(
+                isError=False,
+                workflow_name="test-workflow",
+                content=[TextContent(type="text", text="Missing run_id")]
+            )
+
+    def test_create_trigger_response_missing_required_fields(self):
+        """Test that creating a CreateTriggerResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            CreateTriggerResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing trigger_name")]
+            )
+
+    def test_delete_trigger_response_missing_required_fields(self):
+        """Test that creating a DeleteTriggerResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            DeleteTriggerResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing trigger_name")]
+            )
+
+    def test_get_trigger_response_missing_required_fields(self):
+        """Test that creating a GetTriggerResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            GetTriggerResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing trigger_name and trigger_details")]
+            )
+
+        with pytest.raises(ValidationError):
+            GetTriggerResponse(
+                isError=False,
+                trigger_name="test-trigger",
+                content=[TextContent(type="text", text="Missing trigger_details")]
+            )
+
+    def test_get_triggers_response_missing_required_fields(self):
+        """Test that creating a GetTriggersResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            GetTriggersResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing triggers")]
+            )
+
+    def test_start_trigger_response_missing_required_fields(self):
+        """Test that creating a StartTriggerResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            StartTriggerResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing trigger_name")]
+            )
+
+    def test_stop_trigger_response_missing_required_fields(self):
+        """Test that creating a StopTriggerResponse without required fields raises an error."""
+        with pytest.raises(ValidationError):
+            StopTriggerResponse(
+                isError=False,
+                content=[TextContent(type="text", text="Missing trigger_name")]
+            )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

This commit adds comprehensive AWS Glue Interactive Sessions and Workflows management capabilities to the package. 

### Changes

> Please provide a summary of what's being changed

Added MCP Tools for managing AWS Glue Interactive Sessions and Workflows. AWS Glue Interactive Sessions provide serverless, on-demand Spark and Ray environments for interactive data processing, enabling developers to run code snippets, explore data, and debug ETL jobs in real-time without managing infrastructure. AWS Glue Workflows orchestrate complex ETL pipelines by defining dependencies between jobs, crawlers, and triggers, enabling automated execution of multi-step data processing tasks with visual monitoring and error handling.

This implementation includes: 
* Core functionality for AWS Glue Interactive Sessions and Workflows management
* Comprehensive error handling and validation
* Support for both read-only and write operations with appropriate access controls
* Detailed documentation for each operation

### User experience

> Please share what the user experience looks like before and after this change

Before: Users had limited ability to interact with AWS Glue Interactive Sessions and WorkFlows through LLM interfaces, requiring manual AWS console or CLI interactions for Interactive Sessions and WorkFlows management tasks.

After: Users can now perform comprehensive AWS Glue operations for managing these resources directly through the MCP server, including:

#### Interactive Session: 

Developers can now create Spark/Ray sessions for interactive data exploration and debugging

##### Session Operations:

- create-session: Create Spark/Ray interactive sessions with full configuration
- delete-session: Safely delete MCP-managed sessions
- get-session: Retrieve session details and status
- list-sessions: List all sessions with filtering/pagination
- stop-session: Stop running sessions

##### Statement Operations:

- run-statement: Execute PySpark/Ray code in sessions
- cancel-statement: Cancel running statements
- get-statement: Get statement results and output
- list-statements: List all statements in a session

#### Workflow

Design complex ETL pipelines with dependencies and scheduling

##### Workflow Operations:

- create-workflow: Create ETL workflow orchestrations
- delete-workflow: Remove workflows
- get-workflow: Retrieve workflow details with optional graph
- list-workflows: List all workflows with pagination
- start-workflow-run: Execute workflow runs

##### Trigger Operations:

- create-trigger: Create scheduled/conditional/event triggers
- delete-trigger: Remove triggers
- get-trigger: Retrieve trigger configurations
- get-triggers: List all triggers
- start-trigger/stop-trigger: Control trigger activation

#####  Comprehensive Test Coverage

- 21 tests for workflows handler covering all operations
- 25+ tests for interactive sessions handler
- Full error handling and edge case coverage
- Write access permission testing

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)
N

**RFC issue number**: https://github.com/awslabs/mcp/issues/614

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
