### PR TITLE
fix(dataprocessing-mcp-server): Initialize IS and Workflow in server

### DIFF
--- a/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/server.py
+++ b/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/server.py
@@ -30,6 +30,12 @@ from awslabs.dataprocessing_mcp_server.handlers.glue.data_catalog_handler import
 from awslabs.dataprocessing_mcp_server.handlers.glue.glue_commons_handler import (
     GlueCommonsHandler,
 )
+from awslabs.dataprocessing_mcp_server.handlers.glue.glue_interactive_sessions_handler import (
+    GlueInteractiveSessionsHandler,
+)
+from awslabs.dataprocessing_mcp_server.handlers.glue.glue_worklows_handler import (
+    GlueWorkflowAndTriggerHandler,
+)
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
 
@@ -84,6 +90,12 @@ It enables you to create, manage, and monitor data processing workflows.
 1. Create a security configuration: `manage_aws_glue_security(operation='create-security-configuration', config_name='my-config, encryption_configuration={...})`
 2. Delete a security configuration: `manage_aws_glue_security(operation='delete-security-configuration', config_name='my-config)`
 3. Get a security configuration: `manage_aws_glue_security(operation='get-security-configuration', config_name='my-config)`
+
+### Glue Interactive Sessions
+1. Create a session: `manage_aws_glue_sessions(operation='create-session', session_definition={...})`
+2. Run a statement: `manage_aws_glue_statements(operation='run-statement', session_id='session-id', code='print("Hello, world!")')`
+3. Get statement results: `manage_aws_glue_statements(operation='get-statement', session_id='session-id', statement_id='statement-id')`
+4. Stop a session: `manage_aws_glue_sessions(operation='stop-session', session_id='session-id')`
 
 """
 
@@ -154,6 +166,16 @@ def main():
         allow_sensitive_data_access=allow_sensitive_data_access,
     )
     GlueCommonsHandler(
+        mcp,
+        allow_write=allow_write,
+        allow_sensitive_data_access=allow_sensitive_data_access,
+    )
+    GlueInteractiveSessionsHandler(
+        mcp,
+        allow_write=allow_write,
+        allow_sensitive_data_access=allow_sensitive_data_access,
+    )
+    GlueWorkflowAndTriggerHandler(
         mcp,
         allow_write=allow_write,
         allow_sensitive_data_access=allow_sensitive_data_access,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

This commit adds comprehensive AWS Glue Interactive Sessions and Workflows management capabilities to the package.

### Changes

> Please provide a summary of what's being changed

Initialize IS and Workflow in server

### User experience

> Please share what the user experience looks like before and after this change

Users can now be able to use AWS Glue Interactive Sessions and Workflows management capabilities by running the server.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)
N

**RFC issue number**: https://github.com/awslabs/mcp/issues/614

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
