### PR TITLE
feat(dataprocessing-mcp-server): Add Glue ETL Handler for Glue Job Tools

### DIFF
--- a/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/handlers/glue/glue_etl_handler.py
+++ b/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/handlers/glue/glue_etl_handler.py
@@ -1,0 +1,706 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GlueEtlJobsHandler for Data Processing MCP Server."""
+
+import os
+import json
+from awslabs.dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.dataprocessing_mcp_server.utils.logging_helper import (
+    LogLevel,
+    log_with_request_id,
+)
+from awslabs.dataprocessing_mcp_server.models.glue_models import (
+    BatchStopJobRunResponse,
+    CreateJobResponse,
+    DeleteJobResponse,
+    GetJobBookmarkResponse,
+    GetJobResponse,
+    GetJobRunResponse,
+    GetJobRunsResponse,
+    GetJobsResponse,
+    ResetJobBookmarkResponse,
+    StartJobRunResponse,
+    StopJobRunResponse,
+    UpdateJobResponse,
+)
+
+from mcp.server.fastmcp import Context
+from mcp.types import TextContent
+from pydantic import Field
+from typing import Dict, List, Optional, Tuple, Union, cast, Any
+from botocore.exceptions import ClientError
+
+
+class GlueEtlJobsHandler:
+    """Handler for Amazon Glue ETL Jobs operations."""
+
+    def __init__(
+        self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False
+    ):
+        """Initialize the Glue ETL Jobs handler.
+
+        Args:
+            mcp: The MCP server instance
+            allow_write: Whether to enable write access (default: False)
+            allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+        """
+        self.mcp = mcp
+        self.allow_write = allow_write
+        self.allow_sensitive_data_access = allow_sensitive_data_access
+        self.glue_client = AwsHelper.create_boto3_client("glue")
+
+        # Register tools
+        self.mcp.tool(name="manage_aws_glue_jobs")(self.manage_aws_glue_jobs)
+
+    async def manage_aws_glue_jobs(
+        self,
+        ctx: Context,
+        operation: str = Field(
+            ...,
+            description='Operation to perform: create-job, delete-job, get-job, get-jobs, update-job, start-job-run, stop-job-run, get-job-run, get-job-runs, batch-stop-job-run, get-job-bookmark, reset-job-bookmark. Choose "get-job", "get-jobs", "get-job-run", "get-job-runs", or "get-job-bookmark" for read-only operations when write access is disabled.',
+        ),
+        job_name: Optional[str] = Field(
+            None,
+            description="Name of the job (required for all operations except get-jobs).",
+        ),
+        job_definition: Optional[Dict[str, Any]] = Field(
+            None,
+            description="Job definition for create-job and update-job operations. For create-job, must include Role and Command parameters.",
+        ),
+        job_run_id: Optional[str] = Field(
+            None,
+            description="Job run ID for get-job-run, stop-job-run operations, or to retry for start-job-run operation.",
+        ),
+        job_run_ids: Optional[List[str]] = Field(
+            None,
+            description="List of job run IDs for batch-stop-job-run operation.",
+        ),
+        job_arguments: Optional[Dict[str, str]] = Field(
+            None,
+            description="Job arguments for start-job-run operation. These replace the default arguments set in the job definition.",
+        ),
+        max_results: Optional[int] = Field(
+            None,
+            description="Maximum number of results to return for get-jobs or get-job-runs operations.",
+        ),
+        next_token: Optional[str] = Field(
+            None,
+            description="Pagination token for get-jobs or get-job-runs operations.",
+        ),
+        worker_type: Optional[str] = Field(
+            None,
+            description="Worker type for start-job-run operation (G.1X, G.2X, G.4X, G.8X, G.025X for Spark jobs, Z.2X for Ray jobs).",
+        ),
+        number_of_workers: Optional[int] = Field(
+            None,
+            description="Number of workers for start-job-run operation.",
+        ),
+        max_capacity: Optional[float] = Field(
+            None,
+            description="Maximum capacity in DPUs for start-job-run operation (not compatible with worker_type and number_of_workers).",
+        ),
+        timeout: Optional[int] = Field(
+            None,
+            description="Timeout in minutes for start-job-run operation.",
+        ),
+        security_configuration: Optional[str] = Field(
+            None,
+            description="Security configuration name for start-job-run operation.",
+        ),
+        execution_class: Optional[str] = Field(
+            None,
+            description="Execution class for start-job-run operation (STANDARD or FLEX).",
+        ),
+        job_run_queuing_enabled: Optional[bool] = Field(
+            None,
+            description="Whether job run queuing is enabled for start-job-run operation.",
+        ),
+        predecessors_included: Optional[bool] = Field(
+            None,
+            description="Whether to include predecessor runs in get-job-run operation.",
+        ),
+    ) -> Union[
+        CreateJobResponse,
+        DeleteJobResponse,
+        GetJobResponse,
+        GetJobsResponse,
+        StartJobRunResponse,
+        StopJobRunResponse,
+        UpdateJobResponse,
+        GetJobRunResponse,
+        GetJobRunsResponse,
+        BatchStopJobRunResponse,
+        GetJobBookmarkResponse,
+        ResetJobBookmarkResponse,
+    ]:
+        """Manage AWS Glue ETL jobs and job runs with both read and write operations.
+
+        This tool provides comprehensive operations for managing AWS Glue ETL jobs and job runs,
+        including creating, updating, retrieving, listing, starting, stopping, and monitoring jobs.
+
+        ## Requirements
+        - The server must be run with the `--allow-write` flag for create-job, delete-job, update-job, start-job-run, stop-job-run, and batch-stop-job-run operations
+        - Appropriate AWS permissions for Glue ETL job operations
+
+        ## Job Operations
+        - **create-job**: Create a new ETL job in AWS Glue
+        - **delete-job**: Delete an existing ETL job from AWS Glue
+        - **get-job**: Retrieve detailed information about a specific job
+        - **get-jobs**: List all jobs in your AWS Glue account
+        - **update-job**: Update an existing job's properties
+        - **start-job-run**: Start a job run using a job name
+
+        ## Job Run Operations
+        - **stop-job-run**: Stop a job run using a job name and run ID
+        - **get-job-run**: Retrieve detailed information about a specific job run
+        - **get-job-runs**: List all job runs for a specific job
+        - **batch-stop-job-run**: Stop one or more running jobs
+
+        ## Usage Tips
+        - Job names must be unique within your AWS account and region
+        - Create a script required by the customer and push the script to a customer S3 Location. Ask for S3 Location if not provided.
+        - Verify if the IAM role used has glue trusted entities in the role if not update the role or create a new one
+        - Job definitions should include command, role, and other required parameters
+        - As rule of thumb use Glue Version 5.0 or latest to create jobs
+
+        ## Examples
+        ```
+        # Create a new Spark ETL job
+        {
+          "operation": "create-job",
+          "job_name": "my-etl-job",
+          "job_definition": {
+            "Role": "arn:aws:iam::123456789012:role/GlueETLRole",
+            "Command": {
+              "Name": "glueetl",
+              "ScriptLocation": "s3://my-bucket/scripts/etl-script.py"
+            },
+            "GlueVersion": "5.0",
+            "MaxRetries": 2,
+            "Timeout": 120,
+            "WorkerType": "G.1X",
+            "NumberOfWorkers": 5
+          }
+        }
+
+        # Start a job run
+        {
+          "operation": "start-job-run",
+          "job_name": "my-etl-job",
+          "worker_type": "G.1X",
+          "number_of_workers": 5
+        }
+
+        # Get details of a specific job run
+        {
+          "operation": "get-job-run",
+          "job_name": "my-etl-job",
+          "job_run_id": "jr_1234567890abcdef0"
+        }
+        ```
+
+        Args:
+            ctx: MCP context
+            operation: Operation to perform
+            job_name: Name of the job
+            job_definition: Job definition for create-job and update-job operations
+            job_run_id: Job run ID for get-job-run, stop-job-run operations, or to retry for start-job-run operation
+            job_run_ids: List of job run IDs for batch-stop-job-run operation
+            job_arguments: Job arguments for start-job-run operation
+            max_results: Maximum number of results to return for get-jobs or get-job-runs operations
+            next_token: Pagination token for get-jobs or get-job-runs operations
+            worker_type: Worker type for start-job-run operation
+            number_of_workers: Number of workers for start-job-run operation
+            max_capacity: Maximum capacity in DPUs for start-job-run operation
+            timeout: Timeout in minutes for start-job-run operation
+            security_configuration: Security configuration name for start-job-run operation
+            execution_class: Execution class for start-job-run operation
+            job_run_queuing_enabled: Whether job run queuing is enabled for start-job-run operation
+            predecessors_included: Whether to include predecessor runs in get-job-run operation
+
+        Returns:
+            Union of response types specific to the operation performed
+        """
+        try:
+            log_with_request_id(
+                ctx,
+                LogLevel.INFO,
+                f"Glue ETL Handler - Tool: manage_aws_glue_jobs_and_runs - Operation: {operation}",
+            )
+
+            # Check write access for operations that require it
+            read_only_operations = [
+                "get-job",
+                "get-jobs",
+                "get-job-run",
+                "get-job-runs",
+                "get-job-bookmark",
+            ]
+            if not self.allow_write and operation not in read_only_operations:
+                error_message = (
+                    f"Operation {operation} is not allowed without write access"
+                )
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+
+                # Return appropriate error response based on operation
+                if operation == "create-job":
+                    return CreateJobResponse(
+                        isError=True,
+                        content=[TextContent(type="text", text=error_message)],
+                        job_name="",
+                        job_id="",
+                        operation="create-job",
+                    )
+                elif operation == "delete-job":
+                    return DeleteJobResponse(
+                        isError=True,
+                        content=[TextContent(type="text", text=error_message)],
+                        job_name="",
+                    )
+                elif operation == "start-job-run":
+                    return StartJobRunResponse(
+                        isError=True,
+                        content=[TextContent(type="text", text=error_message)],
+                        job_name="",
+                        job_run_id="",
+                    )
+                elif operation == "stop-job-run":
+                    return StopJobRunResponse(
+                        isError=True,
+                        content=[TextContent(type="text", text=error_message)],
+                        job_name="",
+                        job_run_id="",
+                    )
+                elif operation == "update-job":
+                    return UpdateJobResponse(
+                        isError=True,
+                        content=[TextContent(type="text", text=error_message)],
+                        job_name="",
+                    )
+                elif operation == "batch-stop-job-run":
+                    return BatchStopJobRunResponse(
+                        isError=True,
+                        content=[TextContent(type="text", text=error_message)],
+                        job_name="",
+                        successful_submissions=[],
+                        failed_submissions=[],
+                    )
+
+            # Job operations
+            if operation == "create-job":
+                if job_name is None or job_definition is None:
+                    raise ValueError(
+                        "job_name and job_definition are required for create-job operation"
+                    )
+
+                # Add MCP management tags to job definition
+                resource_tags = AwsHelper.prepare_resource_tags("GlueJob")
+                if "Tags" in job_definition:
+                    job_definition["Tags"].update(resource_tags)
+                else:
+                    job_definition["Tags"] = resource_tags
+
+                # Create the job
+                response = self.glue_client.create_job(Name=job_name, **job_definition)
+
+                return CreateJobResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully created Glue job {job_name} with MCP management tags",
+                        )
+                    ],
+                    job_name=job_name,
+                    job_id=response.get("Name"),
+                )
+
+            elif operation == "delete-job":
+                if job_name is None:
+                    raise ValueError("job_name is required for delete-job operation")
+
+                # Verify that the job is managed by MCP before deleting
+                # Construct the ARN for the job
+                region = AwsHelper.get_aws_region() or "us-east-1"
+                account_id = AwsHelper.get_aws_account_id()
+                job_arn = f"arn:aws:glue:{region}:{account_id}:job/{job_name}"
+
+                # Get job parameters
+                try:
+                    response = self.glue_client.get_job(JobName=job_name)
+                    job = response.get("Job", {})
+                    parameters = job.get("Parameters", {})
+                except ClientError:
+                    parameters = {}
+
+                # Check if the job is managed by MCP
+                if not AwsHelper.is_resource_mcp_managed(
+                    self.glue_client, job_arn, parameters
+                ):
+                    error_message = f"Cannot delete job {job_name} - it is not managed by the MCP server (missing required tags)"
+                    log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                    return DeleteJobResponse(
+                        isError=True,
+                        content=[TextContent(type="text", text=error_message)],
+                        job_name=job_name,
+                    )
+
+                # Delete the job
+                self.glue_client.delete_job(JobName=job_name)
+
+                return DeleteJobResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully deleted MCP-managed Glue job {job_name}",
+                        )
+                    ],
+                    job_name=job_name,
+                )
+
+            elif operation == "get-job":
+                if job_name is None:
+                    raise ValueError("job_name is required for get-job operation")
+
+                # Get the job
+                response = self.glue_client.get_job(JobName=job_name)
+
+                return GetJobResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully retrieved job {job_name}",
+                        )
+                    ],
+                    job_name=job_name,
+                    job_details=response.get("Job", {}),
+                )
+
+            elif operation == "get-jobs":
+                # Prepare parameters
+                params: Dict[str, Any] = {}
+                if max_results is not None:
+                    params["MaxResults"] = max_results
+                if next_token is not None:
+                    params["NextToken"] = next_token
+
+                # Get jobs
+                response = self.glue_client.get_jobs(**params)
+
+                jobs = response.get("Jobs", [])
+                return GetJobsResponse(
+                    isError=False,
+                    content=[
+                        TextContent(type="text", text="Successfully retrieved jobs")
+                    ],
+                    jobs=jobs,
+                    count=len(jobs),
+                    next_token=response.get("NextToken"),
+                    operation="list",
+                )
+
+            elif operation == "update-job":
+                if job_name is None or job_definition is None:
+                    raise ValueError(
+                        "job_name and job_definition are required for update-job operation"
+                    )
+
+                # Verify that the job is managed by MCP before updating
+                try:
+                    # Get the job to check if it's managed by MCP
+                    response = self.glue_client.get_job(JobName=job_name)
+                    job = response.get("Job", {})
+                    parameters = job.get("Parameters", {})
+
+                    # Construct the ARN for the job
+                    region = AwsHelper.get_aws_region() or "us-east-1"
+                    account_id = AwsHelper.get_aws_account_id()
+                    job_arn = f"arn:aws:glue:{region}:{account_id}:job/{job_name}"
+
+                    # Check if the job is managed by MCP
+                    if not AwsHelper.is_resource_mcp_managed(
+                        self.glue_client, job_arn, parameters
+                    ):
+                        error_message = f"Cannot update job {job_name} - it is not managed by the MCP server (missing required tags)"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return UpdateJobResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            job_name=job_name,
+                        )
+
+                    # Update Job does not support updating jobs
+                    job_definition.pop("Tags", None)
+                except ClientError as e:
+                    if e.response["Error"]["Code"] == "EntityNotFoundException":
+                        error_message = f"Job {job_name} not found"
+                        log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                        return UpdateJobResponse(
+                            isError=True,
+                            content=[TextContent(type="text", text=error_message)],
+                            job_name=job_name,
+                        )
+                    else:
+                        raise e
+
+                # Update the job
+                self.glue_client.update_job(JobName=job_name, JobUpdate=job_definition)
+
+                return UpdateJobResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully updated MCP-managed job {job_name}",
+                        )
+                    ],
+                    job_name=job_name,
+                )
+
+            elif operation == "start-job-run":
+                if job_name is None:
+                    raise ValueError("job_name is required for start-job-run operation")
+
+                # Prepare parameters
+                params = {"JobName": job_name}
+                if job_arguments is not None:
+                    params["Arguments"] = json.dumps(job_arguments)
+                if job_run_id is not None:
+                    params["JobRunId"] = job_run_id
+                if timeout is not None:
+                    params["Timeout"] = timeout
+                if security_configuration is not None:
+                    params["SecurityConfiguration"] = security_configuration
+                if job_run_queuing_enabled is not None:
+                    params["JobRunQueuingEnabled"] = str(job_run_queuing_enabled)
+                if execution_class is not None:
+                    params["ExecutionClass"] = execution_class
+
+                # Worker configuration
+                if worker_type is not None and number_of_workers is not None:
+                    params["WorkerType"] = worker_type
+                    params["NumberOfWorkers"] = str(number_of_workers)
+                elif max_capacity is not None:
+                    params["MaxCapacity"] = str(max_capacity)
+
+                # Start job run
+                response = self.glue_client.start_job_run(**params)
+
+                return StartJobRunResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully started job run for {job_name}",
+                        )
+                    ],
+                    job_name=job_name,
+                    job_run_id=response.get("JobRunId", ""),
+                )
+
+            # Job run operations
+            elif operation == "stop-job-run":
+                if job_name is None or job_run_id is None:
+                    raise ValueError(
+                        "job_name and job_run_id are required for stop-job-run operation"
+                    )
+
+                # Stop job run
+                self.glue_client.batch_stop_job_run(
+                    JobName=job_name, JobRunIds=[job_run_id]
+                )
+
+                return StopJobRunResponse(
+                    job_name=job_name,
+                    job_run_id=job_run_id,
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully stopped job run {job_run_id} for job {job_name}",
+                        )
+                    ],
+                )
+
+            elif operation == "get-job-run":
+                if job_name is None or job_run_id is None:
+                    raise ValueError(
+                        "job_name and job_run_id are required for get-job-run operation"
+                    )
+
+                # Prepare parameters
+                params = {"JobName": job_name, "RunId": job_run_id}
+                if predecessors_included is not None:
+                    params["PredecessorsIncluded"] = str(predecessors_included)
+
+                # Get the job run
+                response = self.glue_client.get_job_run(**params)
+
+                return GetJobRunResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully retrieved job run {job_run_id} for job {job_name}",
+                        )
+                    ],
+                    job_name=job_name,
+                    job_run_id=job_run_id,
+                    job_run_details=response.get("JobRun", {}),
+                )
+
+            elif operation == "get-job-runs":
+                if job_name is None:
+                    raise ValueError("job_name is required for get-job-runs operation")
+
+                # Prepare parameters
+                params: Dict[str, Any] = {"JobName": job_name}
+                if max_results is not None:
+                    params["MaxResults"] = max_results
+                if next_token is not None:
+                    params["NextToken"] = next_token
+
+                # Get job runs
+                response = self.glue_client.get_job_runs(**params)
+
+                job_runs = response.get("JobRuns", [])
+                return GetJobRunsResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully retrieved job runs for job {job_name}",
+                        )
+                    ],
+                    job_name=job_name,
+                    job_runs=job_runs,
+                    count=len(job_runs),
+                    next_token=response.get("NextToken"),
+                    operation="list",
+                )
+
+            elif operation == "batch-stop-job-run":
+                if job_name is None:
+                    raise ValueError(
+                        "job_name is required for batch-stop-job-run operation"
+                    )
+                if job_run_id is None and job_run_ids is None:
+                    raise ValueError(
+                        "Either job_run_id or job_run_ids is required for batch-stop-job-run operation"
+                    )
+
+                # Prepare job run IDs
+                run_ids = []
+                if job_run_id is not None:
+                    run_ids.append(job_run_id)
+                if job_run_ids is not None:
+                    run_ids.extend(job_run_ids)
+
+                # Stop job runs
+                response = self.glue_client.batch_stop_job_run(
+                    JobName=job_name, JobRunIds=run_ids
+                )
+
+                return BatchStopJobRunResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully processed batch stop job run request for job {job_name}",
+                        )
+                    ],
+                    job_name=job_name,
+                    successful_submissions=response.get("SuccessfulSubmissions", []),
+                    failed_submissions=response.get("Errors", []),
+                )
+
+            # Job bookmark operations
+            elif operation == "get-job-bookmark":
+                if job_name is None:
+                    raise ValueError(
+                        "job_name is required for get-job-bookmark operation"
+                    )
+
+                # Get the job bookmark
+                response = self.glue_client.get_job_bookmark(JobName=job_name)
+
+                return GetJobBookmarkResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully retrieved job bookmark for job {job_name}",
+                        )
+                    ],
+                    job_name=job_name,
+                    bookmark_details=response.get("JobBookmarkEntry", {}),
+                )
+
+            elif operation == "reset-job-bookmark":
+                if job_name is None:
+                    raise ValueError(
+                        "job_name is required for reset-job-bookmark operation"
+                    )
+
+                # Prepare parameters
+                params = {"JobName": job_name}
+                if job_run_id is not None:
+                    params["RunId"] = job_run_id
+
+                # Reset job bookmark
+                self.glue_client.reset_job_bookmark(**params)
+
+                return ResetJobBookmarkResponse(
+                    isError=False,
+                    content=[
+                        TextContent(
+                            type="text",
+                            text=f"Successfully reset job bookmark for job {job_name}",
+                        )
+                    ],
+                    job_name=job_name,
+                    run_id=job_run_id,
+                )
+
+            else:
+                error_message = (
+                    f"Invalid operation: {operation}. Must be one of: "
+                    "create-job, delete-job, get-job, get-jobs, update-job, start-job-run, "
+                    "stop-job-run, get-job-run, get-job-runs, batch-stop-job-run"
+                )
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                return GetJobResponse(
+                    isError=True,
+                    content=[TextContent(type="text", text=error_message)],
+                    job_name=job_name or "",
+                    job_details={},
+                )
+
+        except ValueError as e:
+            log_with_request_id(
+                ctx, LogLevel.ERROR, f"Parameter validation error: {str(e)}"
+            )
+            raise
+        except Exception as e:
+            error_message = f"Error in manage_aws_glue_jobs_and_runs: {str(e)}"
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+            return GetJobResponse(
+                isError=True,
+                content=[TextContent(type="text", text=error_message)],
+                job_name=job_name or "",
+                job_details={},
+            )

--- a/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/models/glue_models.py
+++ b/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/models/glue_models.py
@@ -195,7 +195,7 @@ class BatchStopJobRunResponse(CallToolResult):
     """Response model for batch stop job run operation."""
 
     job_name: str = Field(..., description='Name of the job')
-    successful_submissions: List[str] = Field(
+    successful_submissions: List[Dict[str, Any]] = Field(
         ..., description='List of successfully stopped job run IDs'
     )
     failed_submissions: List[Dict[str, Any]] = Field(

--- a/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/server.py
+++ b/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/server.py
@@ -30,6 +30,9 @@ from awslabs.dataprocessing_mcp_server.handlers.emr.emr_ec2_instance_handler imp
 from awslabs.dataprocessing_mcp_server.handlers.glue.data_catalog_handler import (
     GlueDataCatalogHandler,
 )
+from awslabs.dataprocessing_mcp_server.handlers.glue.glue_etl_handler import (
+    GlueEtlJobsHandler,
+)
 from awslabs.dataprocessing_mcp_server.handlers.glue.glue_commons_handler import (
     GlueCommonsHandler,
 )
@@ -52,6 +55,20 @@ It enables you to create, manage, and monitor data processing workflows.
 - IAM roles and permissions are critical for data processing services to access data sources and targets.
 
 ## Common Workflows
+
+### Glue ETL Jobs
+1. Create a Glue job: `manage_aws_glue_jobs(operation='create-job', job_name='my-job', job_definition={...})`
+2. Delete a Glue job: `manage_aws_glue_jobs(operation='delete-job', job_name='my-job')`
+3. Get Glue job details: `manage_aws_glue_jobs(operation='get-job', job_name='my-job')`
+4. List Glue jobs: `manage_aws_glue_jobs(operation='get-jobs')`
+5. Update a Glue job: `manage_aws_glue_jobs(operation='update-job', job_name='my-job', job_definition={...})`
+6. Run a Glue job: `manage_aws_glue_jobs(operation='start-job-run', job_name='my-job')`
+7. Stop a Glue job run: `manage_aws_glue_jobs(operation='stop-job-run', job_name='my-job', job_run_id='my-job-run-id')`
+8. Get Glue job run details: `manage_aws_glue_jobs(operation='get-job-run', job_name='my-job', job_run_id='my-job-run-id')`
+9. Get all Glue job runs for a job: `manage_aws_glue_jobs(operation='get-job-runs', job_name='my-job')`
+10. Stop multiple Glue job runs: `manage_aws_glue_jobs(operation='batch-stop-job-run', job_name='my-job', job_run_ids=[...])`
+11. Get Glue job bookmark details: `manage_aws_glue_jobs(operation='get-job-bookmark', job_name='my-job')`
+12. Reset a Glue job bookmark: `manage_aws_glue_jobs(operation='reset-job-bookmark', job_name='my-job')`
 
 ### Setting Up a Data Catalog
 1. Create a database: `manage_aws_glue_databases(operation='create-database', database_name='my-database', description='My database')`
@@ -161,6 +178,11 @@ def main():
 
     # Initialize handlers - all tools are always registered, access control is handled within tools
     GlueDataCatalogHandler(
+        mcp,
+        allow_write=allow_write,
+        allow_sensitive_data_access=allow_sensitive_data_access,
+    )
+    GlueEtlJobsHandler(
         mcp,
         allow_write=allow_write,
         allow_sensitive_data_access=allow_sensitive_data_access,

--- a/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/utils/aws_helper.py
+++ b/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/utils/aws_helper.py
@@ -132,6 +132,25 @@ class AwsHelper:
         return tags
 
     @staticmethod
+    def get_resource_tags_glue_job(glue_client: Any, job_name: str) -> Dict[str, str]:
+        """Get tags for a Glue job.
+
+        Args:
+            glue_client: Glue boto3 client
+            job_name: Glue job name
+
+        Returns:
+            Dictionary of tags
+        """
+        try:
+            response = glue_client.get_tags(
+                ResourceArn=f"arn:aws:glue:*:*:job/{job_name}"
+            )
+            return response.get("Tags", {})
+        except ClientError:
+            return {}
+
+    @staticmethod
     def is_resource_mcp_managed(
         glue_client: Any, resource_arn: str, parameters: Optional[Dict[str, str]] = None
     ) -> bool:

--- a/src/dataprocessing-mcp-server/tests/handlers/glue/test_glue_etl_handler.py
+++ b/src/dataprocessing-mcp-server/tests/handlers/glue/test_glue_etl_handler.py
@@ -1,0 +1,741 @@
+import pytest
+from unittest.mock import Mock, patch
+from botocore.exceptions import ClientError
+from mcp.server.fastmcp import Context
+from awslabs.dataprocessing_mcp_server.handlers.glue.glue_etl_handler import GlueEtlJobsHandler
+
+@pytest.fixture
+def mock_glue_client():
+    return Mock()
+
+
+@pytest.fixture
+def mock_aws_helper():
+    with patch('awslabs.dataprocessing_mcp_server.handlers.glue.glue_etl_handler.AwsHelper') as mock:
+        mock.create_boto3_client.return_value = Mock()
+        mock.get_aws_region.return_value = 'us-east-1'
+        mock.get_aws_account_id.return_value = '123456789012'
+        mock.prepare_resource_tags.return_value = {'mcp-managed': 'true'}
+        mock.is_resource_mcp_managed.return_value = True
+        yield mock
+
+
+@pytest.fixture
+def handler(mock_aws_helper):
+    mcp = Mock()
+    return GlueEtlJobsHandler(mcp, allow_write=True)
+
+
+@pytest.fixture
+def mock_context():
+    return Mock(spec=Context)
+
+
+@pytest.fixture
+def basic_job_definition():
+    return {
+        'Role': 'arn:aws:iam::123456789012:role/GlueETLRole',
+        'Command': {
+            'Name': 'glueetl',
+            'ScriptLocation': 's3://bucket/script.py'
+        },
+        'GlueVersion': '5.0'
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_job_success(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+    mock_glue_client.create_job.return_value = {'Name': 'test-job'}
+
+    ctx = Mock()
+    response = await handler.manage_aws_glue_jobs(
+        ctx,
+        operation='create-job',
+        job_name='test-job',
+        job_definition={
+            'Role': 'test-role',
+            'Command': {'Name': 'glueetl', 'ScriptLocation': 's3://bucket/script.py'}
+        }
+    )
+
+    assert not response.isError
+    assert response.job_name == 'test-job'
+    mock_glue_client.create_job.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_job_missing_parameters(handler):
+    ctx = Mock()
+    with pytest.raises(ValueError):
+        await handler.manage_aws_glue_jobs(
+            ctx,
+            operation='create-job',
+            job_name=None,
+            job_definition=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_job_success(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+    mock_glue_client.get_job.return_value = {'Job': {'Parameters': {}}}
+
+    ctx = Mock()
+    response = await handler.manage_aws_glue_jobs(
+        ctx,
+        operation='delete-job',
+        job_name='test-job'
+    )
+
+    assert not response.isError
+    mock_glue_client.delete_job.assert_called_once_with(JobName='test-job')
+
+
+@pytest.mark.asyncio
+async def test_get_job_success(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+    mock_glue_client.get_job.return_value = {'Job': {'Name': 'test-job'}}
+
+    ctx = Mock()
+    response = await handler.manage_aws_glue_jobs(
+        ctx,
+        operation='get-job',
+        job_name='test-job'
+    )
+
+    assert not response.isError
+    assert response.job_details == {'Name': 'test-job'}
+
+
+@pytest.mark.asyncio
+async def test_get_jobs_success(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+    mock_glue_client.get_jobs.return_value = {
+        'Jobs': [{'Name': 'job1'}, {'Name': 'job2'}],
+        'NextToken': 'token123'
+    }
+
+    ctx = Mock()
+    response = await handler.manage_aws_glue_jobs(
+        ctx,
+        operation='get-jobs',
+        max_results=10,
+        next_token='token'
+    )
+
+    assert not response.isError
+    assert len(response.jobs) == 2
+    assert response.next_token == 'token123'
+
+
+@pytest.mark.asyncio
+async def test_start_job_run_success(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+    mock_glue_client.start_job_run.return_value = {'JobRunId': 'run123'}
+
+    ctx = Mock()
+    response = await handler.manage_aws_glue_jobs(
+        ctx,
+        operation='start-job-run',
+        job_name='test-job',
+        job_arguments=None,
+        worker_type='G.1X',
+        number_of_workers=2
+    )
+
+    assert not response.isError
+    assert response.job_run_id == 'run123'
+
+
+@pytest.mark.asyncio
+async def test_stop_job_run_success(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+
+    ctx = Mock()
+    response = await handler.manage_aws_glue_jobs(
+        ctx,
+        operation='stop-job-run',
+        job_name='test-job',
+        job_run_id='run123'
+    )
+
+    assert not response.isError
+    mock_glue_client.batch_stop_job_run.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_job_operation_without_write_permission(handler):
+    handler.allow_write = False
+
+    ctx = Mock()
+    response = await handler.manage_aws_glue_jobs(
+        ctx,
+        operation='create-job',
+        job_name='test-job',
+    )
+
+    assert response.isError
+
+
+@pytest.mark.asyncio
+async def test_delete_job_operation_without_write_permission(handler):
+    handler.allow_write = False
+
+    ctx = Mock()
+    response = await handler.manage_aws_glue_jobs(
+        ctx,
+        operation='delete-job',
+        job_name='test-job',
+    )
+
+    assert response.isError
+
+
+@pytest.mark.asyncio
+async def test_create_job_operation_invalid_arguments(handler):
+    ctx = Mock()
+    try:
+        response = await handler.manage_aws_glue_jobs(
+            ctx,
+            operation='create-job',
+            job_name=None
+        )
+    except ValueError as e:
+        assert "job_name" in str(e)
+        assert "required" in str(e)
+        return
+    assert False
+
+
+@pytest.mark.asyncio
+async def test_delete_job_operation_invalid_arguments(handler):
+    ctx = Mock()
+    try:
+        response = await handler.manage_aws_glue_jobs(
+            ctx,
+            operation='delete-job',
+            job_name=None
+        )
+    except ValueError as e:
+        assert "job_name" in str(e)
+        assert "required" in str(e)
+        return
+    assert False
+
+
+@pytest.mark.asyncio
+async def test_get_job_operation_invalid_arguments(handler):
+    ctx = Mock()
+    try:
+        response = await handler.manage_aws_glue_jobs(
+            ctx,
+            operation='get-job',
+            job_name=None
+        )
+    except ValueError as e:
+        assert "job_name" in str(e)
+        assert "required" in str(e)
+        return
+    assert False
+
+
+@pytest.mark.asyncio
+async def test_update_job_operation_invalid_arguments(handler):
+    ctx = Mock()
+    try:
+        response = await handler.manage_aws_glue_jobs(
+            ctx,
+            operation='update-job',
+            job_name=None
+        )
+    except ValueError as e:
+        assert "job_name" in str(e)
+        assert "required" in str(e)
+        return
+    assert False
+
+@pytest.mark.asyncio
+async def test_start_job_run_operation_invalid_arguments(handler):
+    ctx = Mock()
+    try:
+        response = await handler.manage_aws_glue_jobs(
+            ctx,
+            operation='start-job-run',
+            job_name=None
+        )
+    except ValueError as e:
+        assert "job_name" in str(e)
+        assert "required" in str(e)
+        return
+    assert False
+
+
+@pytest.mark.asyncio
+async def test_stop_job_run_operation_invalid_arguments(handler):
+    ctx = Mock()
+    try:
+        response = await handler.manage_aws_glue_jobs(
+            ctx,
+            operation='stop-job-run',
+            job_name=None
+        )
+    except ValueError as e:
+        assert "job_name" in str(e)
+        assert "required" in str(e)
+        return
+    assert False
+
+@pytest.mark.asyncio
+async def test_get_job_run_operation_invalid_arguments(handler):
+    ctx = Mock()
+    try:
+        response = await handler.manage_aws_glue_jobs(
+            ctx,
+            operation='get-job-run',
+            job_name=None
+        )
+    except ValueError as e:
+        assert "job_name" in str(e)
+        assert "required" in str(e)
+        return
+    assert False
+
+
+@pytest.mark.asyncio
+async def test_get_job_runs_operation_invalid_arguments(handler):
+    ctx = Mock()
+    try:
+        response = await handler.manage_aws_glue_jobs(
+            ctx,
+            operation='get-job-runs',
+            job_name=None
+        )
+    except ValueError as e:
+        assert "job_name" in str(e)
+        assert "required" in str(e)
+        return
+    assert False
+
+
+@pytest.mark.asyncio
+async def test_batch_stop_job_run_operation_invalid_arguments(handler):
+    ctx = Mock()
+    try:
+        response = await handler.manage_aws_glue_jobs(
+            ctx,
+            operation='batch-stop-job-run',
+            job_name=None
+        )
+    except ValueError as e:
+        assert "job_name" in str(e)
+        assert "required" in str(e)
+        return
+    assert False
+
+
+@pytest.mark.asyncio
+async def test_get_job_bookmark_operation_invalid_arguments(handler):
+    ctx = Mock()
+    try:
+        response = await handler.manage_aws_glue_jobs(
+            ctx,
+            operation='get-job-bookmark',
+            job_name=None
+        )
+    except ValueError as e:
+        assert "job_name" in str(e)
+        assert "required" in str(e)
+        return
+    assert False
+
+
+@pytest.mark.asyncio
+async def test_reset_job_bookmark_operation_invalid_arguments(handler):
+    ctx = Mock()
+    try:
+        response = await handler.manage_aws_glue_jobs(
+            ctx,
+            operation='reset-job-bookmark',
+            job_name=None
+        )
+    except ValueError as e:
+        assert "job_name" in str(e)
+        assert "required" in str(e)
+        return
+    assert False
+
+
+@pytest.mark.asyncio
+async def test_start_job_run_operation_without_write_permission(handler):
+    handler.allow_write = False
+
+    ctx = Mock()
+    response = await handler.manage_aws_glue_jobs(
+        ctx,
+        operation='start-job-run',
+        job_name='test-job',
+    )
+
+    assert response.isError
+
+
+@pytest.mark.asyncio
+async def test_stop_job_run_operation_without_write_permission(handler):
+    handler.allow_write = False
+
+    ctx = Mock()
+    response = await handler.manage_aws_glue_jobs(
+        ctx,
+        operation='stop-job-run',
+        job_name='test-job',
+    )
+
+    assert response.isError
+
+
+@pytest.mark.asyncio
+async def test_batch_stop_job_run_operation_without_write_permission(handler):
+    handler.allow_write = False
+
+    ctx = Mock()
+    response = await handler.manage_aws_glue_jobs(
+        ctx,
+        operation='batch-stop-job-run',
+        job_name='test-job',
+    )
+
+    assert response.isError
+
+
+@pytest.mark.asyncio
+async def test_update_job_operation_without_write_permission(handler):
+    handler.allow_write = False
+
+    ctx = Mock()
+    response = await handler.manage_aws_glue_jobs(
+        ctx,
+        operation='update-job',
+        job_name='test-job',
+        job_definition={}
+    )
+
+    assert response.isError
+
+
+@pytest.mark.asyncio
+async def test_invalid_operation(handler):
+    ctx = Mock()
+    response = await handler.manage_aws_glue_jobs(
+        ctx,
+        operation='invalid-operation',
+        job_name='test-job'
+    )
+
+    assert response.isError
+
+
+@pytest.mark.asyncio
+async def test_client_error_handling(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+    mock_glue_client.get_job.side_effect = ClientError(
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Not found'}},
+        'GetJob'
+    )
+
+    ctx = Mock()
+    response = await handler.manage_aws_glue_jobs(
+        ctx,
+        operation='get-job',
+        job_name='test-job'
+    )
+
+    assert response.isError
+
+
+@pytest.mark.asyncio
+async def test_update_job_does_not_exist(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+    mock_glue_client.get_job.side_effect = ClientError(
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Not found'}},
+        'GetJob'
+    )
+
+    ctx = Mock()
+    response = await handler.manage_aws_glue_jobs(
+        ctx,
+        operation='update-job',
+        job_name='test-job'
+    )
+
+    assert response.isError
+
+
+@pytest.mark.asyncio
+async def test_create_job_with_tags(handler, mock_glue_client, basic_job_definition):
+    handler.glue_client = mock_glue_client
+    job_definition = basic_job_definition.copy()
+    job_definition['Tags'] = {'custom-tag': 'value'}
+    mock_glue_client.create_job.return_value = {'Name': 'test-job'}
+
+    await handler.manage_aws_glue_jobs(
+        Mock(),
+        operation='create-job',
+        job_name='test-job',
+        job_definition=job_definition
+    )
+
+    # Verify tags were merged correctly
+    called_args = mock_glue_client.create_job.call_args[1]
+    assert 'mcp-managed' in called_args['Tags']
+    assert called_args['Tags']['custom-tag'] == 'value'
+
+
+@pytest.mark.asyncio
+async def test_update_job_non_mcp_managed(handler, mock_glue_client, mock_aws_helper):
+    handler.glue_client = mock_glue_client
+    mock_aws_helper.is_resource_mcp_managed.return_value = False
+
+    response = await handler.manage_aws_glue_jobs(
+        Mock(),
+        operation='update-job',
+        job_name='test-job',
+        job_definition={'Role': 'new-role'}
+    )
+
+    assert response.isError
+    assert "not managed by the MCP server" in response.content[0].text
+
+
+# Job run operation tests
+@pytest.mark.asyncio
+async def test_start_job_run_with_all_parameters(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+    mock_glue_client.start_job_run.return_value = {'JobRunId': 'run123'}
+
+    await handler.manage_aws_glue_jobs(
+        Mock(),
+        operation='start-job-run',
+        job_name='test-job',
+        job_arguments={'--conf': 'value'},
+        worker_type='G.1X',
+        number_of_workers=2,
+        timeout=60,
+        security_configuration='sec-config',
+        execution_class='STANDARD',
+        job_run_queuing_enabled=True
+    )
+
+    call_kwargs = mock_glue_client.start_job_run.call_args[1]
+    assert call_kwargs['JobName'] == 'test-job'
+    assert call_kwargs['WorkerType'] == 'G.1X'
+    assert call_kwargs['NumberOfWorkers'] == '2'
+    assert call_kwargs['Timeout'] == 60
+    assert call_kwargs['SecurityConfiguration'] == 'sec-config'
+    assert call_kwargs['ExecutionClass'] == 'STANDARD'
+    assert call_kwargs['JobRunQueuingEnabled'] == 'True'
+
+
+@pytest.mark.asyncio
+async def test_start_job_run_with_max_capacity(handler, mock_glue_client):
+    mock_glue_client.start_job_run.return_value = {'JobRunId': 'runid', }
+    handler.glue_client = mock_glue_client
+
+    await handler.manage_aws_glue_jobs(
+        Mock(),
+        operation='start-job-run',
+        job_arguments=None,
+        job_name='test-job',
+        worker_type=None,
+        max_capacity=10.0
+    )
+
+    called_args = mock_glue_client.start_job_run.call_args[1]
+    assert called_args['MaxCapacity'] == '10.0'
+
+
+# Bookmark operation tests
+@pytest.mark.asyncio
+async def test_get_job_bookmark_success(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+    mock_glue_client.get_job_bookmark.return_value = {
+        'JobBookmarkEntry': {
+            'JobName': 'test-job',
+            'Version': 1,
+            'Run': 0
+        }
+    }
+
+    response = await handler.manage_aws_glue_jobs(
+        Mock(),
+        operation='get-job-bookmark',
+        job_name='test-job'
+    )
+
+    assert not response.isError
+    assert response.bookmark_details['JobName'] == 'test-job'
+
+
+@pytest.mark.asyncio
+async def test_reset_job_bookmark_with_run_id(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+
+    response = await handler.manage_aws_glue_jobs(
+        Mock(),
+        operation='reset-job-bookmark',
+        job_name='test-job',
+        job_run_id='run123'
+    )
+
+    assert not response.isError
+    mock_glue_client.reset_job_bookmark.assert_called_with(
+        JobName='test-job',
+        RunId='run123'
+    )
+
+
+# Batch operations tests
+@pytest.mark.asyncio
+async def test_batch_stop_job_run_multiple_ids(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+    mock_glue_client.batch_stop_job_run.return_value = {
+        'SuccessfulSubmissions': [{'JobRunId': 'run1'}, {'JobRunId': 'run2'}],
+        'Errors': []
+    }
+
+    response = await handler.manage_aws_glue_jobs(
+        Mock(),
+        operation='batch-stop-job-run',
+        job_name='test-job',
+        job_run_ids=['run1', 'run2']
+    )
+
+    assert not response.isError
+    assert len(response.successful_submissions) == 2
+    assert len(response.failed_submissions) == 0
+
+
+@pytest.mark.asyncio
+async def test_batch_stop_job_run_with_failures(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+    mock_glue_client.batch_stop_job_run.return_value = {
+        'SuccessfulSubmissions': [{'JobRunId': 'run1'}],
+        'Errors': [{'JobRunId': 'run2', 'ErrorDetail': {'ErrorCode': 'NotFound'}}]
+    }
+
+    response = await handler.manage_aws_glue_jobs(
+        Mock(),
+        operation='batch-stop-job-run',
+        job_name='test-job',
+        job_run_ids=['run1', 'run2']
+    )
+
+    assert not response.isError
+    assert len(response.successful_submissions) == 1
+    assert len(response.failed_submissions) == 1
+
+
+# Error handling tests
+@pytest.mark.asyncio
+async def test_get_job_runs_with_client_error(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+    mock_glue_client.get_job_runs.side_effect = ClientError(
+        {'Error': {'Code': 'InternalServiceException', 'Message': 'Internal error'}},
+        'GetJobRuns'
+    )
+
+    response = await handler.manage_aws_glue_jobs(
+        Mock(),
+        operation='get-job-runs',
+        job_name='test-job'
+    )
+
+    assert response.isError
+    assert 'Error in manage_aws_glue_jobs_and_runs' in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_pagination_parameters(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+    mock_glue_client.get_job_runs.return_value = {
+        'JobRuns': [],
+        'NextToken': 'next-token'
+    }
+
+    await handler.manage_aws_glue_jobs(
+        Mock(),
+        operation='get-job-runs',
+        job_name='test-job',
+        max_results=50,
+        next_token='current-token'
+    )
+
+    mock_glue_client.get_job_runs.assert_called_with(
+        JobName='test-job',
+        MaxResults=50,
+        NextToken='current-token'
+    )
+
+
+# Security and validation tests
+@pytest.mark.asyncio
+async def test_get_job_run_with_predecessors(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+    mock_glue_client.get_job_run.return_value = {'Name': 'test-job', 'JobRun': {}}
+
+    await handler.manage_aws_glue_jobs(
+        Mock(),
+        operation='get-job-run',
+        job_name='test-job',
+        job_run_id='run123',
+        predecessors_included=True
+    )
+
+    mock_glue_client.get_job_run.assert_called_with(
+        JobName='test-job',
+        RunId='run123',
+        PredecessorsIncluded='True'
+    )
+
+
+@pytest.mark.asyncio
+async def test_initialization_parameters():
+    mcp = Mock()
+    handler = GlueEtlJobsHandler(
+        mcp,
+        allow_write=True,
+        allow_sensitive_data_access=True
+    )
+
+    assert handler.allow_write
+    assert handler.allow_sensitive_data_access
+    assert handler.mcp == mcp
+
+
+@pytest.mark.asyncio
+async def test_missing_required_parameters(handler):
+    with pytest.raises(ValueError):
+        await handler.manage_aws_glue_jobs(
+            Mock(),
+            operation='get-job-run'
+        )
+
+
+@pytest.mark.asyncio
+async def test_invalid_execution_class(handler, mock_glue_client):
+    handler.glue_client = mock_glue_client
+    mock_glue_client.start_job_run.side_effect = ClientError(
+        {'Error': {'Code': 'ValidationException', 'Message': 'Invalid execution class'}},
+        'StartJobRun'
+    )
+
+    response = await handler.manage_aws_glue_jobs(
+        Mock(),
+        operation='start-job-run',
+        job_name='test-job',
+        execution_class='INVALID'
+    )
+
+    assert response.isError
+
+

--- a/src/dataprocessing-mcp-server/tests/utils/test_aws_helper.py
+++ b/src/dataprocessing-mcp-server/tests/utils/test_aws_helper.py
@@ -189,6 +189,34 @@ class TestAwsHelper:
             assert tags['tag1'] == 'value1'
             assert tags['tag2'] == 'value2'
 
+    def test_get_resource_tags_glue_job(self):
+        mock_glue_client = MagicMock()
+        mock_glue_client.get_tags.return_value = {
+            'Tags': {MCP_MANAGED_TAG_KEY: MCP_MANAGED_TAG_VALUE}
+        }
+
+        result = AwsHelper.get_resource_tags_glue_job(mock_glue_client, "jobname")
+        assert result[MCP_MANAGED_TAG_KEY] == MCP_MANAGED_TAG_VALUE
+
+    def test_get_resource_tags_for_untagged_glue_job(self):
+        mock_glue_client = MagicMock()
+        mock_glue_client.get_tags.return_value = {
+            'Tags': {}
+        }
+
+        result = AwsHelper.get_resource_tags_glue_job(mock_glue_client, "jobname")
+        assert len(result) == 0
+
+    def test_get_resource_tags_for_glue_job_client_error(self):
+        mock_glue_client = MagicMock()
+        mock_glue_client.get_tags.side_effect = ClientError(
+            {'Error': {'Code': 'AccessDeniedException', 'Message': 'Access denied'}},
+            'GetTags',
+        )
+
+        result = AwsHelper.get_resource_tags_glue_job(mock_glue_client, "jobname")
+        assert len(result) == 0
+
     def test_is_resource_mcp_managed_with_tags(self):
         """Test that is_resource_mcp_managed returns True when the resource has the MCP managed tag."""
         # Mock the Glue client


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

Add MCP Tools for managing AWS Glue Jobs. This includes all required tools for creating, deleting, updating and running Glue jobs.

This implementation includes:
* Core functionality for AWS Glue Usage Profiles and Security Config management
* Standardized operation naming conventions with hyphenated format (e.g., 'create-job', 'start-job-run')
* Comprehensive error handling and validation
* Support for both read-only and write operations with appropriate access controls
* Detailed documentation for each operation

### User experience

> Please share what the user experience looks like before and after this change

Before: Users had limited ability to interact with AWS Glue Jobs through LLM interfaces, requiring manual AWS console or CLI interactions for creation/deletion/update management tasks.

After: Users can now perform comprehensive AWS Glue operations for managing these resources directly through the MCP server, including:
* Creating, updating, retrieving, and deleting jobs
* Starting, retrieving and stopping job runs
* Retrieving and resetting job bookmarks

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)
* N

**RFC issue number**: https://github.com/awslabs/mcp/issues/614

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
