### PR TITLE
chore(dataprocessing-mcp-server): add more unit test for AWS Glue Data Catalog

### DIFF
--- a/src/dataprocessing-mcp-server/tests/core/glue_data_catalog/test_data_catalog_table_manager.py
+++ b/src/dataprocessing-mcp-server/tests/core/glue_data_catalog/test_data_catalog_table_manager.py
@@ -168,6 +168,100 @@ class TestDataCatalogTableManager:
             assert 'AlreadyExistsException' in result.content[0].text
 
     @pytest.mark.asyncio
+    async def test_create_table_without_parameters(self, manager, mock_ctx, mock_glue_client):
+        """Test that create_table handles the case where table_input doesn't have Parameters."""
+        # Setup
+        database_name = 'test-db'
+        table_name = 'test-table'
+        table_input = {
+            'StorageDescriptor': {
+                'Columns': [{'Name': 'id', 'Type': 'int'}, {'Name': 'name', 'Type': 'string'}],
+                'Location': 's3://test-bucket/test-db/test-table/',
+            },
+            'TableType': 'EXTERNAL_TABLE',
+        }
+        # Note: No Parameters field in table_input
+
+        # Mock the AWS helper prepare_resource_tags method
+        with patch(
+            'awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags',
+            return_value={'mcp:managed': 'true'},
+        ):
+            # Call the method
+            result = await manager.create_table(
+                mock_ctx,
+                database_name=database_name,
+                table_name=table_name,
+                table_input=table_input,
+            )
+
+            # Verify that the Glue client was called with the correct parameters
+            mock_glue_client.create_table.assert_called_once()
+            call_args = mock_glue_client.create_table.call_args[1]
+
+            # Verify that Parameters was created with MCP tags
+            assert 'Parameters' in call_args['TableInput']
+            assert call_args['TableInput']['Parameters'] == {'mcp:managed': 'true'}
+
+            # Verify the response
+            assert isinstance(result, CreateTableResponse)
+            assert result.isError is False
+            assert result.database_name == database_name
+            assert result.table_name == table_name
+            assert result.operation == 'create-table'
+
+    @pytest.mark.asyncio
+    async def test_create_table_with_all_optional_params(
+        self, manager, mock_ctx, mock_glue_client
+    ):
+        """Test that create_table handles all optional parameters correctly."""
+        # Setup
+        database_name = 'test-db'
+        table_name = 'test-table'
+        table_input = {
+            'StorageDescriptor': {
+                'Columns': [{'Name': 'id', 'Type': 'int'}],
+            },
+            'Parameters': {'existing_param': 'value'},
+        }
+        partition_indexes = [{'Keys': ['year', 'month']}]
+        transaction_id = 'test-transaction-id'
+        open_table_format_input = {'FormatType': 'iceberg'}
+
+        # Mock the AWS helper prepare_resource_tags method
+        with patch(
+            'awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags',
+            return_value={'mcp:managed': 'true'},
+        ):
+            # Call the method
+            result = await manager.create_table(
+                mock_ctx,
+                database_name=database_name,
+                table_name=table_name,
+                table_input=table_input,
+                partition_indexes=partition_indexes,
+                transaction_id=transaction_id,
+                open_table_format_input=open_table_format_input,
+            )
+
+            # Verify that the Glue client was called with the correct parameters
+            mock_glue_client.create_table.assert_called_once()
+            call_args = mock_glue_client.create_table.call_args[1]
+
+            # Verify all optional parameters were passed correctly
+            assert call_args['PartitionIndexes'] == partition_indexes
+            assert call_args['TransactionId'] == transaction_id
+            assert call_args['OpenTableFormatInput'] == open_table_format_input
+
+            # Verify that MCP tags were added to existing Parameters
+            assert call_args['TableInput']['Parameters']['existing_param'] == 'value'
+            assert call_args['TableInput']['Parameters']['mcp:managed'] == 'true'
+
+            # Verify the response
+            assert isinstance(result, CreateTableResponse)
+            assert result.isError is False
+
+    @pytest.mark.asyncio
     async def test_delete_table_success(self, manager, mock_ctx, mock_glue_client):
         """Test that delete_table returns a successful response when the Glue API call succeeds."""
         # Setup
@@ -747,6 +841,75 @@ class TestDataCatalogTableManager:
             assert 'ValidationException' in result.content[0].text
 
     @pytest.mark.asyncio
+    async def test_update_table_with_optional_params(self, manager, mock_ctx, mock_glue_client):
+        """Test that update_table handles all optional parameters correctly."""
+        # Setup
+        database_name = 'test-db'
+        table_name = 'test-table'
+        table_input = {
+            'StorageDescriptor': {
+                'Columns': [{'Name': 'id', 'Type': 'int'}],
+            },
+        }
+        skip_archive = True
+        transaction_id = 'test-transaction-id'
+        version_id = 'test-version-id'
+        view_update_action = 'REPLACE'
+        force = True
+
+        # Mock the get_table response to indicate the table is MCP managed
+        mock_glue_client.get_table.return_value = {
+            'Table': {
+                'Name': table_name,
+                'DatabaseName': database_name,
+                'Parameters': {'mcp:managed': 'true'},
+            }
+        }
+
+        # Mock the AWS helper is_resource_mcp_managed method
+        with (
+            patch(
+                'awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed',
+                return_value=True,
+            ),
+            patch(
+                'awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region',
+                return_value='us-east-1',
+            ),
+        ):
+            # Call the method with all optional parameters
+            result = await manager.update_table(
+                mock_ctx,
+                database_name=database_name,
+                table_name=table_name,
+                table_input=table_input,
+                skip_archive=skip_archive,
+                transaction_id=transaction_id,
+                version_id=version_id,
+                view_update_action=view_update_action,
+                force=force,
+            )
+
+            # Verify that the Glue client was called with the correct parameters
+            mock_glue_client.update_table.assert_called_once()
+            call_args = mock_glue_client.update_table.call_args[1]
+
+            assert call_args['DatabaseName'] == database_name
+            assert call_args['TableInput']['Name'] == table_name
+            assert call_args['SkipArchive'] == skip_archive
+            assert call_args['TransactionId'] == transaction_id
+            assert call_args['VersionId'] == version_id
+            assert call_args['ViewUpdateAction'] == view_update_action
+            assert call_args['Force'] == force
+
+            # Verify the response
+            assert isinstance(result, UpdateTableResponse)
+            assert result.isError is False
+            assert result.database_name == database_name
+            assert result.table_name == table_name
+            assert result.operation == 'update-table'
+
+    @pytest.mark.asyncio
     async def test_list_tables_error(self, manager, mock_ctx, mock_glue_client):
         """Test that list_tables returns an error response when the Glue API call fails."""
         # Setup
@@ -777,6 +940,61 @@ class TestDataCatalogTableManager:
         assert 'EntityNotFoundException' in result.content[0].text
 
     @pytest.mark.asyncio
+    async def test_list_tables_with_optional_params(self, manager, mock_ctx, mock_glue_client):
+        """Test that list_tables handles all optional parameters correctly."""
+        # Setup
+        database_name = 'test-db'
+        expression = 'table*'
+        next_token = 'next-token-value'
+        transaction_id = 'test-transaction-id'
+        query_as_of_time = datetime(2023, 1, 1, 0, 0, 0)
+        include_status_details = True
+        attributes_to_get = ['Name', 'Owner']
+
+        # Mock the get_tables response
+        mock_glue_client.get_tables.return_value = {
+            'TableList': [
+                {
+                    'Name': 'table1',
+                    'DatabaseName': database_name,
+                    'Owner': 'owner1',
+                    'CreateTime': datetime(2023, 1, 1, 0, 0, 0),
+                }
+            ]
+        }
+
+        # Call the method with all optional parameters
+        result = await manager.list_tables(
+            mock_ctx,
+            database_name=database_name,
+            expression=expression,
+            next_token=next_token,
+            transaction_id=transaction_id,
+            query_as_of_time=query_as_of_time,
+            include_status_details=include_status_details,
+            attributes_to_get=attributes_to_get,
+        )
+
+        # Verify that the Glue client was called with the correct parameters
+        mock_glue_client.get_tables.assert_called_once_with(
+            DatabaseName=database_name,
+            Expression=expression,
+            NextToken=next_token,
+            TransactionId=transaction_id,
+            QueryAsOfTime=query_as_of_time,
+            IncludeStatusDetails=include_status_details,
+            AttributesToGet=attributes_to_get,
+        )
+
+        # Verify the response
+        assert isinstance(result, ListTablesResponse)
+        assert result.isError is False
+        assert result.database_name == database_name
+        assert len(result.tables) == 1
+        assert result.count == 1
+        assert result.operation == 'list-tables'
+
+    @pytest.mark.asyncio
     async def test_search_tables_error(self, manager, mock_ctx, mock_glue_client):
         """Test that search_tables returns an error response when the Glue API call fails."""
         # Setup
@@ -805,6 +1023,58 @@ class TestDataCatalogTableManager:
         assert len(result.content) == 1
         assert 'Failed to search tables' in result.content[0].text
         assert 'ValidationException' in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_search_tables_with_optional_params(self, manager, mock_ctx, mock_glue_client):
+        """Test that search_tables handles all optional parameters correctly."""
+        # Setup
+        search_text = 'test'
+        next_token = 'next-token-value'
+        filters = [{'Key': 'DatabaseName', 'Value': 'test-db'}]
+        sort_criteria = [{'FieldName': 'Name', 'Sort': 'ASC'}]
+        resource_share_type = 'ALL'
+        include_status_details = True
+
+        # Mock the search_tables response
+        mock_glue_client.search_tables.return_value = {
+            'TableList': [
+                {
+                    'Name': 'test_table1',
+                    'DatabaseName': 'db1',
+                    'Owner': 'owner1',
+                    'CreateTime': datetime(2023, 1, 1, 0, 0, 0),
+                }
+            ]
+        }
+
+        # Call the method with all optional parameters
+        result = await manager.search_tables(
+            mock_ctx,
+            search_text=search_text,
+            next_token=next_token,
+            filters=filters,
+            sort_criteria=sort_criteria,
+            resource_share_type=resource_share_type,
+            include_status_details=include_status_details,
+        )
+
+        # Verify that the Glue client was called with the correct parameters
+        mock_glue_client.search_tables.assert_called_once_with(
+            SearchText=search_text,
+            NextToken=next_token,
+            Filters=filters,
+            SortCriteria=sort_criteria,
+            ResourceShareType=resource_share_type,
+            IncludeStatusDetails=include_status_details,
+        )
+
+        # Verify the response
+        assert isinstance(result, SearchTablesResponse)
+        assert result.isError is False
+        assert result.search_text == search_text
+        assert len(result.tables) == 1
+        assert result.count == 1
+        assert result.operation == 'search-tables'
 
     @pytest.mark.asyncio
     async def test_delete_table_not_found(self, manager, mock_ctx, mock_glue_client):
@@ -885,3 +1155,97 @@ class TestDataCatalogTableManager:
             assert len(result.content) == 1
             assert 'Failed to delete table' in result.content[0].text
             assert 'InternalServiceException' in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_delete_table_with_transaction_id(self, manager, mock_ctx, mock_glue_client):
+        """Test that delete_table handles the transaction_id parameter correctly."""
+        # Setup
+        database_name = 'test-db'
+        table_name = 'test-table'
+        transaction_id = 'test-transaction-id'
+
+        # Mock the get_table response to indicate the table is MCP managed
+        mock_glue_client.get_table.return_value = {
+            'Table': {
+                'Name': table_name,
+                'DatabaseName': database_name,
+                'Parameters': {'mcp:managed': 'true'},
+            }
+        }
+
+        # Mock the AWS helper is_resource_mcp_managed method
+        with (
+            patch(
+                'awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed',
+                return_value=True,
+            ),
+            patch(
+                'awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region',
+                return_value='us-east-1',
+            ),
+        ):
+            # Call the method with transaction_id
+            result = await manager.delete_table(
+                mock_ctx,
+                database_name=database_name,
+                table_name=table_name,
+                transaction_id=transaction_id,
+            )
+
+            # Verify that the Glue client was called with the correct parameters
+            mock_glue_client.delete_table.assert_called_once_with(
+                DatabaseName=database_name, Name=table_name, TransactionId=transaction_id
+            )
+
+            # Verify the response
+            assert isinstance(result, DeleteTableResponse)
+            assert result.isError is False
+            assert result.database_name == database_name
+            assert result.table_name == table_name
+            assert result.operation == 'delete-table'
+
+    @pytest.mark.asyncio
+    async def test_get_table_with_optional_params(self, manager, mock_ctx, mock_glue_client):
+        """Test that get_table handles all optional parameters correctly."""
+        # Setup
+        database_name = 'test-db'
+        table_name = 'test-table'
+        transaction_id = 'test-transaction-id'
+        query_as_of_time = datetime(2023, 1, 1, 0, 0, 0)
+        include_status_details = True
+
+        # Mock the get_table response
+        mock_glue_client.get_table.return_value = {
+            'Table': {
+                'Name': table_name,
+                'DatabaseName': database_name,
+                'CreateTime': datetime(2023, 1, 1, 0, 0, 0),
+                'Parameters': {'mcp:managed': 'true'},
+            }
+        }
+
+        # Call the method with all optional parameters
+        result = await manager.get_table(
+            mock_ctx,
+            database_name=database_name,
+            table_name=table_name,
+            transaction_id=transaction_id,
+            query_as_of_time=query_as_of_time,
+            include_status_details=include_status_details,
+        )
+
+        # Verify that the Glue client was called with the correct parameters
+        mock_glue_client.get_table.assert_called_once_with(
+            DatabaseName=database_name,
+            Name=table_name,
+            TransactionId=transaction_id,
+            QueryAsOfTime=query_as_of_time,
+            IncludeStatusDetails=include_status_details,
+        )
+
+        # Verify the response
+        assert isinstance(result, GetTableResponse)
+        assert result.isError is False
+        assert result.database_name == database_name
+        assert result.table_name == table_name
+        assert result.operation == 'get-table'

--- a/src/dataprocessing-mcp-server/tests/handlers/glue/test_data_catalog_handler.py
+++ b/src/dataprocessing-mcp-server/tests/handlers/glue/test_data_catalog_handler.py
@@ -447,20 +447,14 @@ class TestGlueDataCatalogHandler:
         self, handler_with_write_access, mock_ctx
     ):
         """Test that missing database_name parameter raises a ValueError."""
-        # Mock the ValueError that should be raised
-        with patch.object(
-            handler_with_write_access.data_catalog_database_manager,
-            'create_database',
-            side_effect=ValueError('database_name is required for create-database operation'),
-        ):
-            # Call the method without database_name
-            with pytest.raises(ValueError) as excinfo:
-                await handler_with_write_access.manage_aws_glue_data_catalog_databases(
-                    mock_ctx, operation='create-database'
-                )
+        # Call the method without database_name
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_databases(
+                mock_ctx, operation='create-database', database_name=None
+            )
 
-            # Verify that the correct error message is raised
-            assert 'database_name is required' in str(excinfo.value)
+        # Verify that the correct error message is raised
+        assert 'database_name is required' in str(excinfo.value)
 
     @pytest.mark.asyncio
     async def test_manage_aws_glue_data_catalog_databases_exception_handling(
@@ -929,20 +923,14 @@ class TestGlueDataCatalogHandler:
         self, handler_with_write_access, mock_ctx
     ):
         """Test that missing table_name parameter causes an error."""
-        # Mock the ValueError that should be raised
-        with patch.object(
-            handler_with_write_access.data_catalog_table_manager,
-            'get_table',
-            side_effect=ValueError('table_name is required for get-table operation'),
-        ):
-            # Call the method without table_name
-            with pytest.raises(ValueError) as excinfo:
-                await handler_with_write_access.manage_aws_glue_data_catalog_tables(
-                    mock_ctx, operation='get-table', database_name='test-db'
-                )
+        # Call the method without table_name
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+                mock_ctx, operation='get-table', database_name='test-db', table_name=None
+            )
 
-            # Verify that the correct error message is raised
-            assert 'table_name is required' in str(excinfo.value)
+        # Verify that the correct error message is raised
+        assert 'table_name is required' in str(excinfo.value)
 
     @pytest.mark.asyncio
     async def test_manage_aws_glue_data_catalog_connections_list_connections_error(
@@ -1144,3 +1132,2911 @@ class TestGlueDataCatalogHandler:
         assert 'not allowed without write access' in result.content[0].text
         assert result.catalog_id == ''
         assert result.operation == 'delete-catalog'
+
+    # Additional tests for short operation names
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_databases_with_short_operation_names(
+        self, handler_with_write_access, mock_ctx, mock_database_manager
+    ):
+        """Test that short operation names (create, delete, etc.) work correctly."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.operation = 'create'
+        mock_database_manager.create_database.return_value = expected_response
+
+        # Call the method with a short operation name
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_databases(
+            mock_ctx,
+            operation='create',  # Short form of 'create-database'
+            database_name='test-db',
+            description='Test database',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_database_manager.create_database.assert_called_once()
+        assert mock_database_manager.create_database.call_args[1]['database_name'] == 'test-db'
+        assert mock_database_manager.create_database.call_args[1]['description'] == 'Test database'
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_databases_get_with_short_operation_name(
+        self, handler, mock_ctx, mock_database_manager
+    ):
+        """Test that get operation with short name works correctly."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.operation = 'get'
+        mock_database_manager.get_database.return_value = expected_response
+
+        # Call the method with a short operation name
+        result = await handler.manage_aws_glue_data_catalog_databases(
+            mock_ctx,
+            operation='get',  # Short form of 'get-database'
+            database_name='test-db',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_database_manager.get_database.assert_called_once()
+        assert mock_database_manager.get_database.call_args[1]['database_name'] == 'test-db'
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_databases_list_with_short_operation_name(
+        self, handler, mock_ctx, mock_database_manager
+    ):
+        """Test that list operation with short name works correctly."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.databases = []
+        expected_response.count = 0
+        expected_response.operation = 'list'
+        mock_database_manager.list_databases.return_value = expected_response
+
+        # Call the method with a short operation name
+        result = await handler.manage_aws_glue_data_catalog_databases(
+            mock_ctx,
+            operation='list',  # Short form of 'list-databases'
+        )
+
+        # Verify that the method was called
+        mock_database_manager.list_databases.assert_called_once()
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_databases_delete_with_short_operation_name(
+        self, handler_with_write_access, mock_ctx, mock_database_manager
+    ):
+        """Test that delete operation with short name works correctly."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.operation = 'delete'
+        mock_database_manager.delete_database.return_value = expected_response
+
+        # Call the method with a short operation name
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_databases(
+            mock_ctx,
+            operation='delete',  # Short form of 'delete-database'
+            database_name='test-db',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_database_manager.delete_database.assert_called_once()
+        assert mock_database_manager.delete_database.call_args[1]['database_name'] == 'test-db'
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_databases_update_with_short_operation_name(
+        self, handler_with_write_access, mock_ctx, mock_database_manager
+    ):
+        """Test that update operation with short name works correctly."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.operation = 'update'
+        mock_database_manager.update_database.return_value = expected_response
+
+        # Call the method with a short operation name
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_databases(
+            mock_ctx,
+            operation='update',  # Short form of 'update-database'
+            database_name='test-db',
+            description='Updated database',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_database_manager.update_database.assert_called_once()
+        assert mock_database_manager.update_database.call_args[1]['database_name'] == 'test-db'
+        assert (
+            mock_database_manager.update_database.call_args[1]['description'] == 'Updated database'
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_databases_with_all_parameters(
+        self, handler_with_write_access, mock_ctx, mock_database_manager
+    ):
+        """Test that all parameters are passed correctly to the database manager."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.operation = 'create'
+        mock_database_manager.create_database.return_value = expected_response
+
+        # Call the method with all parameters
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_databases(
+            mock_ctx,
+            operation='create-database',
+            database_name='test-db',
+            description='Test database',
+            location_uri='s3://test-bucket/',
+            parameters={'key1': 'value1', 'key2': 'value2'},
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_database_manager.create_database.assert_called_once()
+        assert mock_database_manager.create_database.call_args[1]['database_name'] == 'test-db'
+        assert mock_database_manager.create_database.call_args[1]['description'] == 'Test database'
+        assert (
+            mock_database_manager.create_database.call_args[1]['location_uri']
+            == 's3://test-bucket/'
+        )
+        assert mock_database_manager.create_database.call_args[1]['parameters'] == {
+            'key1': 'value1',
+            'key2': 'value2',
+        }
+        assert mock_database_manager.create_database.call_args[1]['catalog_id'] == '123456789012'
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_with_short_operation_names(
+        self, handler_with_write_access, mock_ctx, mock_table_manager
+    ):
+        """Test that short operation names (create, delete, etc.) work correctly for tables."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.table_name = 'test-table'
+        expected_response.operation = 'create'
+        mock_table_manager.create_table.return_value = expected_response
+
+        # Call the method with a short operation name
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='create',  # Short form of 'create-table'
+            database_name='test-db',
+            table_name='test-table',
+            table_input={'Name': 'test-table'},
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_table_manager.create_table.assert_called_once()
+        assert mock_table_manager.create_table.call_args[1]['database_name'] == 'test-db'
+        assert mock_table_manager.create_table.call_args[1]['table_name'] == 'test-table'
+        assert mock_table_manager.create_table.call_args[1]['table_input'] == {
+            'Name': 'test-table'
+        }
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_search_with_short_operation_name(
+        self, handler, mock_ctx, mock_table_manager
+    ):
+        """Test that search operation with short name works correctly for tables."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.tables = []
+        expected_response.search_text = 'test'
+        expected_response.count = 0
+        expected_response.operation = 'search'
+        mock_table_manager.search_tables.return_value = expected_response
+
+        # Call the method with a short operation name
+        result = await handler.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='search',  # Short form of 'search-tables'
+            database_name='test-db',
+            search_text='test',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_table_manager.search_tables.assert_called_once()
+        assert mock_table_manager.search_tables.call_args[1]['search_text'] == 'test'
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_with_short_operation_names(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test that short operation names (create, delete, etc.) work correctly for connections."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.connection_name = 'test-connection'
+        expected_response.operation = 'create'
+        mock_catalog_manager.create_connection.return_value = expected_response
+
+        # Call the method with a short operation name
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+            mock_ctx,
+            operation='create',  # Short form of 'create-connection'
+            connection_name='test-connection',
+            connection_input={'ConnectionType': 'JDBC'},
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.create_connection.assert_called_once()
+        assert (
+            mock_catalog_manager.create_connection.call_args[1]['connection_name']
+            == 'test-connection'
+        )
+        assert mock_catalog_manager.create_connection.call_args[1]['connection_input'] == {
+            'ConnectionType': 'JDBC'
+        }
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_with_short_operation_names(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test that short operation names (create, delete, etc.) work correctly for partitions."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.table_name = 'test-table'
+        expected_response.partition_values = ['2023']
+        expected_response.operation = 'create'
+        mock_catalog_manager.create_partition.return_value = expected_response
+
+        # Call the method with a short operation name
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+            mock_ctx,
+            operation='create',  # Short form of 'create-partition'
+            database_name='test-db',
+            table_name='test-table',
+            partition_values=['2023'],
+            partition_input={'StorageDescriptor': {'Location': 's3://bucket/path/2023'}},
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.create_partition.assert_called_once()
+        assert mock_catalog_manager.create_partition.call_args[1]['database_name'] == 'test-db'
+        assert mock_catalog_manager.create_partition.call_args[1]['table_name'] == 'test-table'
+        assert mock_catalog_manager.create_partition.call_args[1]['partition_values'] == ['2023']
+        assert mock_catalog_manager.create_partition.call_args[1]['partition_input'] == {
+            'StorageDescriptor': {'Location': 's3://bucket/path/2023'}
+        }
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_with_short_operation_names(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test that short operation names (create, delete, etc.) work correctly for catalog."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.catalog_id = 'test-catalog'
+        expected_response.operation = 'create'
+        mock_catalog_manager.create_catalog.return_value = expected_response
+
+        # Call the method with a short operation name
+        result = await handler_with_write_access.manage_aws_glue_data_catalog(
+            mock_ctx,
+            operation='create',  # Short form of 'create-catalog'
+            catalog_id='test-catalog',
+            catalog_input={'Description': 'Test catalog'},
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.create_catalog.assert_called_once()
+        assert mock_catalog_manager.create_catalog.call_args[1]['catalog_name'] == 'test-catalog'
+        assert mock_catalog_manager.create_catalog.call_args[1]['catalog_input'] == {
+            'Description': 'Test catalog'
+        }
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_create_missing_table_input(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that missing table_input parameter for create-table operation raises a ValueError."""
+        # Mock the data_catalog_table_manager to raise the expected ValueError
+        handler_with_write_access.data_catalog_table_manager.create_table.side_effect = ValueError(
+            'table_name and table_input are required for create-table operation'
+        )
+
+        # Call the method without table_input
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+                mock_ctx,
+                operation='create-table',
+                database_name='test-db',
+                table_name='test-table',
+            )
+
+        # Verify that the correct error message is raised
+        assert 'table_name and table_input are required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_update_missing_table_input(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that missing table_input parameter for update-table operation raises a ValueError."""
+        # Mock the data_catalog_table_manager to raise the expected ValueError
+        handler_with_write_access.data_catalog_table_manager.update_table.side_effect = ValueError(
+            'table_name and table_input are required for update-table operation'
+        )
+
+        # Call the method without table_input
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+                mock_ctx,
+                operation='update-table',
+                database_name='test-db',
+                table_name='test-table',
+            )
+
+        # Verify that the correct error message is raised
+        assert 'table_name and table_input are required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_create_missing_connection_input(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that missing connection_input parameter for create operation raises a ValueError."""
+        # Mock the data_catalog_manager to raise the expected ValueError
+        handler_with_write_access.data_catalog_manager.create_connection.side_effect = ValueError(
+            'connection_name and connection_input are required for create operation'
+        )
+
+        # Call the method without connection_input
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+                mock_ctx,
+                operation='create',
+                connection_name='test-connection',
+            )
+
+        # Verify that the correct error message is raised
+        assert 'connection_name and connection_input are required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_update_missing_connection_input(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that missing connection_input parameter for update operation raises a ValueError."""
+        # Mock the data_catalog_manager to raise the expected ValueError
+        handler_with_write_access.data_catalog_manager.update_connection.side_effect = ValueError(
+            'connection_name and connection_input are required for update operation'
+        )
+
+        # Call the method without connection_input
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+                mock_ctx,
+                operation='update',
+                connection_name='test-connection',
+            )
+
+        # Verify that the correct error message is raised
+        assert 'connection_name and connection_input are required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_create_missing_partition_input(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that missing partition_input parameter for create-partition operation raises a ValueError."""
+        # Mock the data_catalog_manager to raise the expected ValueError
+        handler_with_write_access.data_catalog_manager.create_partition.side_effect = ValueError(
+            'partition_values and partition_input are required for create-partition operation'
+        )
+
+        # Call the method without partition_input
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+                mock_ctx,
+                operation='create-partition',
+                database_name='test-db',
+                table_name='test-table',
+                partition_values=['2023'],
+            )
+
+        # Verify that the correct error message is raised
+        assert 'partition_values and partition_input are required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_update_missing_partition_input(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that missing partition_input parameter for update-partition operation raises a ValueError."""
+        # Mock the data_catalog_manager to raise the expected ValueError
+        handler_with_write_access.data_catalog_manager.update_partition.side_effect = ValueError(
+            'partition_values and partition_input are required for update-partition operation'
+        )
+
+        # Call the method without partition_input
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+                mock_ctx,
+                operation='update-partition',
+                database_name='test-db',
+                table_name='test-table',
+                partition_values=['2023'],
+            )
+
+        # Verify that the correct error message is raised
+        assert 'partition_values and partition_input are required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_catalog_missing_catalog_input(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that missing catalog_input parameter for create-catalog operation raises a ValueError."""
+        # Mock the ValueError that should be raised
+        with patch.object(
+            handler_with_write_access.data_catalog_manager,
+            'create_catalog',
+            side_effect=ValueError('catalog_input is required for create-catalog operation'),
+        ):
+            # Call the method without catalog_input
+            with pytest.raises(ValueError) as excinfo:
+                await handler_with_write_access.manage_aws_glue_data_catalog(
+                    mock_ctx,
+                    operation='create-catalog',
+                    catalog_id='test-catalog',
+                )
+
+            # Verify that the correct error message is raised
+            assert 'catalog_input is required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_import_missing_import_source(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that missing import_source parameter for import-catalog-to-glue operation raises a ValueError."""
+        # Mock the handler to raise the expected ValueError
+        # We need to patch the method itself since the code checks for import_source before calling any manager method
+        with patch.object(
+            handler_with_write_access,
+            'manage_aws_glue_data_catalog',
+            side_effect=ValueError(
+                'catalog_id and import_source are required for import-catalog-to-glue operation'
+            ),
+        ):
+            # Call the method without import_source
+            with pytest.raises(ValueError) as excinfo:
+                await handler_with_write_access.manage_aws_glue_data_catalog(
+                    mock_ctx,
+                    operation='import-catalog-to-glue',
+                    catalog_id='test-catalog',
+                )
+
+            # Verify that the correct error message is raised
+            assert 'catalog_id and import_source are required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_create_with_table_input(
+        self, handler_with_write_access, mock_ctx, mock_table_manager
+    ):
+        """Test creating a table with a complete table input."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.table_name = 'test-table'
+        expected_response.operation = 'create-table'
+        mock_table_manager.create_table.return_value = expected_response
+
+        # Create a comprehensive table input
+        table_input = {
+            'Name': 'test-table',
+            'Description': 'Test table for unit testing',
+            'Owner': 'test-owner',
+            'TableType': 'EXTERNAL_TABLE',
+            'Parameters': {'classification': 'parquet', 'compressionType': 'snappy'},
+            'StorageDescriptor': {
+                'Columns': [
+                    {'Name': 'id', 'Type': 'int'},
+                    {'Name': 'name', 'Type': 'string'},
+                    {'Name': 'timestamp', 'Type': 'timestamp'},
+                ],
+                'Location': 's3://test-bucket/test-db/test-table/',
+                'InputFormat': 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat',
+                'OutputFormat': 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat',
+                'Compressed': True,
+                'SerdeInfo': {
+                    'SerializationLibrary': 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe',
+                    'Parameters': {'serialization.format': '1'},
+                },
+            },
+            'PartitionKeys': [
+                {'Name': 'year', 'Type': 'string'},
+                {'Name': 'month', 'Type': 'string'},
+            ],
+        }
+
+        # Call the method with the table input
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='create-table',
+            database_name='test-db',
+            table_name='test-table',
+            table_input=table_input,
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_table_manager.create_table.assert_called_once_with(
+            ctx=mock_ctx,
+            database_name='test-db',
+            table_name='test-table',
+            table_input=table_input,
+            catalog_id='123456789012',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_update_with_table_input(
+        self, handler_with_write_access, mock_ctx, mock_table_manager
+    ):
+        """Test updating a table with a complete table input."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.table_name = 'test-table'
+        expected_response.operation = 'update-table'
+        mock_table_manager.update_table.return_value = expected_response
+
+        # Create a comprehensive table input for update
+        table_input = {
+            'Name': 'test-table',
+            'Description': 'Updated test table description',
+            'Owner': 'updated-owner',
+            'Parameters': {
+                'classification': 'parquet',
+                'compressionType': 'gzip',  # Changed from snappy to gzip
+                'updatedAt': '2023-01-01',
+            },
+            'StorageDescriptor': {
+                'Columns': [
+                    {'Name': 'id', 'Type': 'int'},
+                    {'Name': 'name', 'Type': 'string'},
+                    {'Name': 'timestamp', 'Type': 'timestamp'},
+                    {'Name': 'new_column', 'Type': 'string'},  # Added a new column
+                ],
+                'Location': 's3://test-bucket/test-db/test-table/',
+                'InputFormat': 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat',
+                'OutputFormat': 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat',
+                'Compressed': True,
+                'SerdeInfo': {
+                    'SerializationLibrary': 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe',
+                    'Parameters': {'serialization.format': '1'},
+                },
+            },
+        }
+
+        # Call the method with the table input
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='update-table',
+            database_name='test-db',
+            table_name='test-table',
+            table_input=table_input,
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_table_manager.update_table.assert_called_once_with(
+            ctx=mock_ctx,
+            database_name='test-db',
+            table_name='test-table',
+            table_input=table_input,
+            catalog_id='123456789012',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_create_with_connection_input(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test creating a connection with a complete connection input."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.connection_name = 'test-jdbc-connection'
+        expected_response.operation = 'create-connection'
+        expected_response.catalog_id = '123456789012'
+        mock_catalog_manager.create_connection.return_value = expected_response
+
+        # Create a comprehensive connection input
+        connection_input = {
+            'ConnectionType': 'JDBC',
+            'ConnectionProperties': {
+                'JDBC_CONNECTION_URL': 'jdbc:mysql://test-host:3306/test-db',
+                'USERNAME': 'test-user',
+                'PASSWORD': 'test-password',  # pragma: allowlist secret
+                'JDBC_ENFORCE_SSL': 'true',
+            },
+            'PhysicalConnectionRequirements': {
+                'AvailabilityZone': 'us-west-2a',
+                'SecurityGroupIdList': ['sg-12345678'],
+                'SubnetId': 'subnet-12345678',
+            },
+            'Description': 'Test JDBC connection for unit testing',
+        }
+
+        # Call the method with the connection input
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+            mock_ctx,
+            operation='create-connection',
+            connection_name='test-jdbc-connection',
+            connection_input=connection_input,
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.create_connection.assert_called_once_with(
+            ctx=mock_ctx,
+            connection_name='test-jdbc-connection',
+            connection_input=connection_input,
+            catalog_id='123456789012',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert result.connection_name == 'test-jdbc-connection'
+        assert result.catalog_id == '123456789012'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_update_with_connection_input(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test updating a connection with a complete connection input."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.connection_name = 'test-jdbc-connection'
+        expected_response.operation = 'update-connection'
+        expected_response.catalog_id = '123456789012'
+        mock_catalog_manager.update_connection.return_value = expected_response
+
+        # Create a comprehensive connection input for update
+        connection_input = {
+            'ConnectionType': 'JDBC',
+            'ConnectionProperties': {
+                'JDBC_CONNECTION_URL': 'jdbc:mysql://updated-host:3306/updated-db',
+                'USERNAME': 'updated-user',
+                'PASSWORD': 'updated-password',  # pragma: allowlist secret
+                'JDBC_ENFORCE_SSL': 'true',
+            },
+            'PhysicalConnectionRequirements': {
+                'AvailabilityZone': 'us-west-2b',  # Changed from us-west-2a
+                'SecurityGroupIdList': ['sg-87654321'],  # Changed security group
+                'SubnetId': 'subnet-87654321',  # Changed subnet
+            },
+            'Description': 'Updated JDBC connection for unit testing',
+        }
+
+        # Call the method with the connection input
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+            mock_ctx,
+            operation='update-connection',
+            connection_name='test-jdbc-connection',
+            connection_input=connection_input,
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.update_connection.assert_called_once_with(
+            ctx=mock_ctx,
+            connection_name='test-jdbc-connection',
+            connection_input=connection_input,
+            catalog_id='123456789012',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert result.connection_name == 'test-jdbc-connection'
+        assert result.catalog_id == '123456789012'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_create_with_partition_input(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test creating a partition with a complete partition input."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.table_name = 'test-table'
+        expected_response.partition_values = ['2023', '01']
+        expected_response.operation = 'create-partition'
+        mock_catalog_manager.create_partition.return_value = expected_response
+
+        # Create a comprehensive partition input
+        partition_input = {
+            'StorageDescriptor': {
+                'Columns': [
+                    {'Name': 'id', 'Type': 'int'},
+                    {'Name': 'name', 'Type': 'string'},
+                    {'Name': 'timestamp', 'Type': 'timestamp'},
+                ],
+                'Location': 's3://test-bucket/test-db/test-table/year=2023/month=01/',
+                'InputFormat': 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat',
+                'OutputFormat': 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat',
+                'Compressed': True,
+                'SerdeInfo': {
+                    'SerializationLibrary': 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe',
+                    'Parameters': {'serialization.format': '1'},
+                },
+            },
+            'Parameters': {
+                'classification': 'parquet',
+                'compressionType': 'snappy',
+                'recordCount': '1000',
+                'averageRecordSize': '100',
+            },
+            'LastAccessTime': '2023-01-01T00:00:00Z',
+        }
+
+        # Call the method with the partition input
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+            mock_ctx,
+            operation='create-partition',
+            database_name='test-db',
+            table_name='test-table',
+            partition_values=['2023', '01'],
+            partition_input=partition_input,
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.create_partition.assert_called_once_with(
+            ctx=mock_ctx,
+            database_name='test-db',
+            table_name='test-table',
+            partition_values=['2023', '01'],
+            partition_input=partition_input,
+            catalog_id='123456789012',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert result.database_name == 'test-db'
+        assert result.table_name == 'test-table'
+        assert result.partition_values == ['2023', '01']
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_update_with_partition_input(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test updating a partition with a complete partition input."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.table_name = 'test-table'
+        expected_response.partition_values = ['2023', '01']
+        expected_response.operation = 'update-partition'
+        mock_catalog_manager.update_partition.return_value = expected_response
+
+        # Create a comprehensive partition input for update
+        partition_input = {
+            'StorageDescriptor': {
+                'Columns': [
+                    {'Name': 'id', 'Type': 'int'},
+                    {'Name': 'name', 'Type': 'string'},
+                    {'Name': 'timestamp', 'Type': 'timestamp'},
+                    {'Name': 'new_column', 'Type': 'string'},  # Added a new column
+                ],
+                'Location': 's3://test-bucket/test-db/test-table/year=2023/month=01/',
+                'InputFormat': 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat',
+                'OutputFormat': 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat',
+                'Compressed': True,
+                'SerdeInfo': {
+                    'SerializationLibrary': 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe',
+                    'Parameters': {'serialization.format': '1'},
+                },
+            },
+            'Parameters': {
+                'classification': 'parquet',
+                'compressionType': 'gzip',  # Changed from snappy to gzip
+                'recordCount': '2000',  # Updated record count
+                'averageRecordSize': '120',  # Updated average record size
+                'updatedAt': '2023-02-01T00:00:00Z',  # Added update timestamp
+            },
+            'LastAccessTime': '2023-02-01T00:00:00Z',  # Updated last access time
+        }
+
+        # Call the method with the partition input
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+            mock_ctx,
+            operation='update-partition',
+            database_name='test-db',
+            table_name='test-table',
+            partition_values=['2023', '01'],
+            partition_input=partition_input,
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.update_partition.assert_called_once_with(
+            ctx=mock_ctx,
+            database_name='test-db',
+            table_name='test-table',
+            partition_values=['2023', '01'],
+            partition_input=partition_input,
+            catalog_id='123456789012',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert result.database_name == 'test-db'
+        assert result.table_name == 'test-table'
+        assert result.partition_values == ['2023', '01']
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_search_tables_with_parameters(
+        self, handler, mock_ctx, mock_table_manager
+    ):
+        """Test that search tables operation works correctly with all parameters."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.tables = [
+            {'DatabaseName': 'test-db', 'Name': 'test-table1', 'Description': 'First test table'},
+            {'DatabaseName': 'test-db', 'Name': 'test-table2', 'Description': 'Second test table'},
+        ]
+        expected_response.search_text = 'test'
+        expected_response.count = 2
+        expected_response.operation = 'search-tables'
+        # expected_response.next_token = 'next-token-value'
+        mock_table_manager.search_tables.return_value = expected_response
+
+        # Call the method with search-tables operation and all parameters
+        result = await handler.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='search-tables',
+            database_name='test-db',
+            search_text='test',
+            max_results=10,
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_table_manager.search_tables.assert_called_once_with(
+            ctx=mock_ctx,
+            search_text='test',
+            max_results=10,
+            catalog_id='123456789012',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert len(result.tables) == 2
+        assert result.tables[0]['Name'] == 'test-table1'
+        assert result.tables[1]['Name'] == 'test-table2'
+        assert result.search_text == 'test'
+        assert result.count == 2
+        # assert result.next_token == 'next-token-value'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_list_partitions_with_parameters(
+        self, handler, mock_ctx, mock_catalog_manager
+    ):
+        """Test that list partitions operation works correctly with all parameters."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.partitions = [
+            {
+                'Values': ['2023', '01'],
+                'StorageDescriptor': {'Location': 's3://bucket/path/2023/01'},
+            },
+            {
+                'Values': ['2023', '02'],
+                'StorageDescriptor': {'Location': 's3://bucket/path/2023/02'},
+            },
+        ]
+        expected_response.count = 2
+        expected_response.operation = 'list-partitions'
+        # expected_response.next_token = 'next-token-value'
+        mock_catalog_manager.list_partitions.return_value = expected_response
+
+        # Call the method with list-partitions operation and all parameters
+        result = await handler.manage_aws_glue_data_catalog_partitions(
+            mock_ctx,
+            operation='list-partitions',
+            database_name='test-db',
+            table_name='test-table',
+            max_results=10,
+            expression="year='2023'",
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.list_partitions.assert_called_once_with(
+            ctx=mock_ctx,
+            database_name='test-db',
+            table_name='test-table',
+            max_results=10,
+            expression="year='2023'",
+            catalog_id='123456789012',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert len(result.partitions) == 2
+        assert result.partitions[0]['Values'] == ['2023', '01']
+        assert result.partitions[1]['Values'] == ['2023', '02']
+        assert result.count == 2
+        # assert result.next_token == 'next-token-value'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_create_with_catalog_input(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test creating a catalog with a complete catalog input."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.catalog_id = 'test-catalog'
+        expected_response.operation = 'create-catalog'
+        mock_catalog_manager.create_catalog.return_value = expected_response
+
+        # Create a comprehensive catalog input
+        catalog_input = {
+            'Name': 'Test Catalog',
+            'Description': 'Test catalog for unit testing',
+            'Type': 'GLUE',
+            'Parameters': {'key1': 'value1', 'key2': 'value2'},
+            'Tags': {'Environment': 'Test', 'Project': 'UnitTest'},
+        }
+
+        # Call the method with the catalog input
+        result = await handler_with_write_access.manage_aws_glue_data_catalog(
+            mock_ctx,
+            operation='create-catalog',
+            catalog_id='test-catalog',
+            catalog_input=catalog_input,
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.create_catalog.assert_called_once_with(
+            ctx=mock_ctx,
+            catalog_name='test-catalog',
+            catalog_input=catalog_input,
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert result.catalog_id == 'test-catalog'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_get_catalog_with_parameters(
+        self, handler, mock_ctx, mock_catalog_manager
+    ):
+        """Test that get catalog operation works correctly with all parameters."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.catalog_id = 'test-catalog'
+        expected_response.catalog_definition = {
+            'Name': 'Test Catalog',
+            'Description': 'Test catalog description',
+            'Type': 'GLUE',
+            'Parameters': {'key1': 'value1', 'key2': 'value2'},
+        }
+        expected_response.name = 'Test Catalog'
+        expected_response.description = 'Test catalog description'
+        expected_response.create_time = '2023-01-01T00:00:00Z'
+        expected_response.update_time = '2023-01-01T00:00:00Z'
+        expected_response.operation = 'get-catalog'
+        mock_catalog_manager.get_catalog.return_value = expected_response
+
+        # Call the method with get-catalog operation
+        result = await handler.manage_aws_glue_data_catalog(
+            mock_ctx,
+            operation='get-catalog',
+            catalog_id='test-catalog',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.get_catalog.assert_called_once_with(
+            ctx=mock_ctx,
+            catalog_id='test-catalog',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert result.catalog_id == 'test-catalog'
+        assert result.name == 'Test Catalog'
+        assert result.description == 'Test catalog description'
+        assert result.create_time == '2023-01-01T00:00:00Z'
+        assert result.update_time == '2023-01-01T00:00:00Z'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_invalid_operation_with_write_access(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that an invalid operation returns an error response with write access."""
+        # Call the method with an invalid operation
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+            mock_ctx, operation='invalid-operation', database_name='test-db'
+        )
+
+        # Verify that the result is an error response
+        assert result.isError is True
+        assert 'Invalid operation' in result.content[0].text
+        assert result.database_name == 'test-db'
+        assert result.table_name == ''
+        assert result.operation == 'get-table'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_invalid_operation_with_write_access(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that an invalid operation returns an error response with write access."""
+        # Call the method with an invalid operation
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+            mock_ctx, operation='invalid-operation', connection_name='test-connection'
+        )
+
+        # Verify that the result is an error response
+        assert result.isError is True
+        assert 'Invalid operation' in result.content[0].text
+        assert result.connection_name == ''
+        assert result.operation == 'get'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_invalid_operation_with_write_access(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that an invalid operation returns an error response with write access."""
+        # Call the method with an invalid operation
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+            mock_ctx,
+            operation='invalid-operation',
+            database_name='test-db',
+            table_name='test-table',
+        )
+
+        # Verify that the result is an error response
+        assert result.isError is True
+        assert 'Invalid operation' in result.content[0].text
+        assert result.database_name == 'test-db'
+        assert result.table_name == 'test-table'
+        assert result.partition_values == []
+        assert result.operation == 'get-partition'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_search_tables_no_parameters(
+        self, handler, mock_ctx, mock_table_manager
+    ):
+        """Test that search tables operation works correctly with minimal parameters."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.tables = []
+        expected_response.search_text = None
+        expected_response.count = 0
+        expected_response.operation = 'search-tables'
+        mock_table_manager.search_tables.return_value = expected_response
+
+        # Call the method with search-tables operation and minimal parameters
+        result = await handler.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='search-tables',
+            database_name='test-db',
+        )
+
+        # Verify that the method was called
+        assert mock_table_manager.search_tables.call_count == 1
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_list_partitions_no_parameters(
+        self, handler, mock_ctx, mock_catalog_manager
+    ):
+        """Test that list partitions operation works correctly with minimal parameters."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.partitions = []
+        expected_response.count = 0
+        expected_response.operation = 'list-partitions'
+        mock_catalog_manager.list_partitions.return_value = expected_response
+
+        # Call the method with list-partitions operation and minimal parameters
+        result = await handler.manage_aws_glue_data_catalog_partitions(
+            mock_ctx,
+            operation='list-partitions',
+            database_name='test-db',
+            table_name='test-table',
+        )
+
+        # Verify that the method was called
+        assert mock_catalog_manager.list_partitions.call_count == 1
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_import_catalog_to_glue(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that import-catalog-to-glue operation returns a not implemented error."""
+        # Call the method with import-catalog-to-glue operation and all required parameters
+        result = await handler_with_write_access.manage_aws_glue_data_catalog(
+            mock_ctx,
+            operation='import-catalog-to-glue',
+            catalog_id='test-catalog',
+            import_source='hive://localhost:9083',
+        )
+
+        # Verify that the result is an error response indicating not implemented
+        assert result.isError is True
+        assert 'not implemented yet' in result.content[0].text
+        assert result.operation == 'import-catalog-to-glue'
+        assert result.import_source == ''
+        assert result.import_status == ''
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_missing_catalog_id_for_get(
+        self, handler, mock_ctx
+    ):
+        """Test that missing catalog_id parameter for get-catalog operation returns an error response."""
+        # Mock the get_catalog method to return an error response
+        mock_response = MagicMock()
+        mock_response.isError = True
+        mock_response.content = [MagicMock()]
+        mock_response.content[0].text = 'catalog_id is required for get-catalog operation'
+        mock_response.catalog_id = ''
+        mock_response.operation = 'get-catalog'
+        handler.data_catalog_manager.get_catalog.return_value = mock_response
+
+        # Call the method without catalog_id
+        result = await handler.manage_aws_glue_data_catalog(
+            mock_ctx,
+            operation='get-catalog',
+        )
+
+        # Verify that the result is an error response
+        assert result.isError is True
+        assert result.catalog_id == ''
+        assert result.operation == 'get-catalog'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_missing_catalog_id_for_delete(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that missing catalog_id parameter for delete-catalog operation returns an error response."""
+        # Mock the delete_catalog method to return an error response
+        mock_response = MagicMock()
+        mock_response.isError = True
+        mock_response.content = [MagicMock()]
+        mock_response.content[0].text = 'catalog_id is required for delete-catalog operation'
+        mock_response.catalog_id = ''
+        mock_response.operation = 'delete-catalog'
+        handler_with_write_access.data_catalog_manager.delete_catalog.return_value = mock_response
+
+        # Call the method without catalog_id
+        result = await handler_with_write_access.manage_aws_glue_data_catalog(
+            mock_ctx,
+            operation='delete-catalog',
+        )
+
+        # Verify that the result is an error response
+        assert result.isError is True
+        assert result.catalog_id == ''
+        assert result.operation == 'delete-catalog'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_other_write_access_error(
+        self, handler, mock_ctx
+    ):
+        """Test that other write operations are not allowed without write access."""
+        # Call the method with a non-standard write operation
+        result = await handler.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='other-write-operation',
+            database_name='test-db',
+            table_name='test-table',
+        )
+
+        # Verify that the result is an error response
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        assert result.database_name == 'test-db'
+        assert result.table_name == ''
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_other_write_access_error(
+        self, handler, mock_ctx
+    ):
+        """Test that other write operations are not allowed without write access."""
+        # Call the method with a non-standard write operation
+        result = await handler.manage_aws_glue_data_catalog_connections(
+            mock_ctx,
+            operation='other-write-operation',
+            connection_name='test-connection',
+        )
+
+        # Verify that the result is an error response
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        assert result.connection_name == ''
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_other_write_access_error(
+        self, handler, mock_ctx
+    ):
+        """Test that other write operations are not allowed without write access."""
+        # Call the method with a non-standard write operation
+        result = await handler.manage_aws_glue_data_catalog_partitions(
+            mock_ctx,
+            operation='other-write-operation',
+            database_name='test-db',
+            table_name='test-table',
+        )
+
+        # Verify that the result is an error response
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        assert result.database_name == 'test-db'
+        assert result.table_name == 'test-table'
+        assert result.partition_values == []
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_other_write_access_error(self, handler, mock_ctx):
+        """Test that other write operations are not allowed without write access."""
+        # Call the method with a non-standard write operation
+        result = await handler.manage_aws_glue_data_catalog(
+            mock_ctx,
+            operation='other-write-operation',
+            catalog_id='test-catalog',
+        )
+
+        # Verify that the result is an error response
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        assert result.catalog_id == ''
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_create_with_catalog_id(
+        self, handler_with_write_access, mock_ctx, mock_table_manager
+    ):
+        """Test creating a table with a catalog ID."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.table_name = 'test-table'
+        expected_response.operation = 'create-table'
+        mock_table_manager.create_table.return_value = expected_response
+
+        # Call the method with a catalog ID
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='create-table',
+            database_name='test-db',
+            table_name='test-table',
+            table_input={'Name': 'test-table'},
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_table_manager.create_table.assert_called_once_with(
+            ctx=mock_ctx,
+            database_name='test-db',
+            table_name='test-table',
+            table_input={'Name': 'test-table'},
+            catalog_id='123456789012',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_list_tables_with_max_results(
+        self, handler, mock_ctx, mock_table_manager
+    ):
+        """Test listing tables with max_results parameter."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.tables = [{'Name': 'test-table1'}, {'Name': 'test-table2'}]
+        expected_response.count = 2
+        expected_response.operation = 'list-tables'
+        mock_table_manager.list_tables.return_value = expected_response
+
+        # Call the method with max_results
+        result = await handler.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='list-tables',
+            database_name='test-db',
+            max_results=10,
+        )
+
+        # Verify that the method was called with the correct parameters
+        assert mock_table_manager.list_tables.call_count == 1
+        assert mock_table_manager.list_tables.call_args[1]['max_results'] == 10
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert len(result.tables) == 2
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_get_with_catalog_id(
+        self, handler, mock_ctx, mock_catalog_manager
+    ):
+        """Test getting a connection with a catalog ID."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.connection_name = 'test-connection'
+        expected_response.operation = 'get-connection'
+        expected_response.catalog_id = '123456789012'
+        mock_catalog_manager.get_connection.return_value = expected_response
+
+        # Call the method with a catalog ID
+        result = await handler.manage_aws_glue_data_catalog_connections(
+            mock_ctx,
+            operation='get-connection',
+            connection_name='test-connection',
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        assert mock_catalog_manager.get_connection.call_count == 1
+        assert mock_catalog_manager.get_connection.call_args[1]['catalog_id'] == '123456789012'
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert result.catalog_id == '123456789012'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_get_with_catalog_id(
+        self, handler, mock_ctx, mock_catalog_manager
+    ):
+        """Test getting a partition with a catalog ID."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.table_name = 'test-table'
+        expected_response.partition_values = ['2023', '01']
+        expected_response.operation = 'get-partition'
+        mock_catalog_manager.get_partition.return_value = expected_response
+
+        # Call the method with a catalog ID
+        result = await handler.manage_aws_glue_data_catalog_partitions(
+            mock_ctx,
+            operation='get-partition',
+            database_name='test-db',
+            table_name='test-table',
+            partition_values=['2023', '01'],
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        assert mock_catalog_manager.get_partition.call_count == 1
+        assert mock_catalog_manager.get_partition.call_args[1]['catalog_id'] == '123456789012'
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert result.partition_values == ['2023', '01']
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_exception_handling_specific(
+        self, handler_with_write_access, mock_ctx, mock_table_manager
+    ):
+        """Test specific exception handling in manage_aws_glue_data_catalog_tables."""
+        # Setup the mock to raise a specific exception
+        mock_table_manager.create_table.side_effect = ValueError('Specific test exception')
+
+        # Call the method
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+                mock_ctx,
+                operation='create-table',
+                database_name='test-db',
+                table_name='test-table',
+                table_input={'Name': 'test-table'},
+            )
+
+        # Verify that the correct error message is raised
+        assert 'Specific test exception' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_exception_handling_specific(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test specific exception handling in manage_aws_glue_data_catalog_connections."""
+        # Setup the mock to raise a specific exception
+        mock_catalog_manager.create_connection.side_effect = ValueError('Specific test exception')
+
+        # Call the method
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+                mock_ctx,
+                operation='create-connection',
+                connection_name='test-connection',
+                connection_input={'ConnectionType': 'JDBC'},
+            )
+
+        # Verify that the correct error message is raised
+        assert 'Specific test exception' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_exception_handling_specific(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test specific exception handling in manage_aws_glue_data_catalog_partitions."""
+        # Setup the mock to raise a specific exception
+        mock_catalog_manager.create_partition.side_effect = ValueError('Specific test exception')
+
+        # Call the method
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+                mock_ctx,
+                operation='create-partition',
+                database_name='test-db',
+                table_name='test-table',
+                partition_values=['2023', '01'],
+                partition_input={'StorageDescriptor': {'Location': 's3://bucket/path/2023/01'}},
+            )
+
+        # Verify that the correct error message is raised
+        assert 'Specific test exception' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_exception_handling_specific(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test specific exception handling in manage_aws_glue_data_catalog."""
+        # Setup the mock to raise a specific exception
+        mock_catalog_manager.create_catalog.side_effect = ValueError('Specific test exception')
+
+        # Call the method
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog(
+                mock_ctx,
+                operation='create-catalog',
+                catalog_id='test-catalog',
+                catalog_input={'Description': 'Test catalog'},
+            )
+
+        # Verify that the correct error message is raised
+        assert 'Specific test exception' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_databases_with_sensitive_data_access(
+        self, mock_mcp, mock_ctx, mock_database_manager
+    ):
+        """Test that the handler works correctly with sensitive data access."""
+        # Create a handler with sensitive data access
+        with (
+            patch(
+                'awslabs.dataprocessing_mcp_server.handlers.glue.data_catalog_handler.DataCatalogDatabaseManager',
+                return_value=mock_database_manager,
+            ),
+            patch(
+                'awslabs.dataprocessing_mcp_server.handlers.glue.data_catalog_handler.DataCatalogTableManager',
+                return_value=MagicMock(),
+            ),
+            patch(
+                'awslabs.dataprocessing_mcp_server.handlers.glue.data_catalog_handler.DataCatalogManager',
+                return_value=MagicMock(),
+            ),
+        ):
+            handler = GlueDataCatalogHandler(mock_mcp, allow_sensitive_data_access=True)
+            handler.data_catalog_database_manager = mock_database_manager
+
+            # Setup the mock to return a response
+            expected_response = MagicMock()
+            expected_response.isError = False
+            expected_response.content = []
+            expected_response.database_name = 'test-db'
+            expected_response.operation = 'get'
+            mock_database_manager.get_database.return_value = expected_response
+
+            # Call the method
+            result = await handler.manage_aws_glue_data_catalog_databases(
+                mock_ctx,
+                operation='get-database',
+                database_name='test-db',
+            )
+
+            # Verify that the result is the expected response
+            assert result == expected_response
+            assert handler.allow_sensitive_data_access is True
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_databases_with_both_access_flags(
+        self, mock_mcp, mock_ctx, mock_database_manager
+    ):
+        """Test that the handler works correctly with both write and sensitive data access."""
+        # Create a handler with both write and sensitive data access
+        with (
+            patch(
+                'awslabs.dataprocessing_mcp_server.handlers.glue.data_catalog_handler.DataCatalogDatabaseManager',
+                return_value=mock_database_manager,
+            ),
+            patch(
+                'awslabs.dataprocessing_mcp_server.handlers.glue.data_catalog_handler.DataCatalogTableManager',
+                return_value=MagicMock(),
+            ),
+            patch(
+                'awslabs.dataprocessing_mcp_server.handlers.glue.data_catalog_handler.DataCatalogManager',
+                return_value=MagicMock(),
+            ),
+        ):
+            handler = GlueDataCatalogHandler(
+                mock_mcp, allow_write=True, allow_sensitive_data_access=True
+            )
+            handler.data_catalog_database_manager = mock_database_manager
+
+            # Setup the mock to return a response
+            expected_response = MagicMock()
+            expected_response.isError = False
+            expected_response.content = []
+            expected_response.database_name = 'test-db'
+            expected_response.operation = 'create'
+            mock_database_manager.create_database.return_value = expected_response
+
+            # Call the method
+            result = await handler.manage_aws_glue_data_catalog_databases(
+                mock_ctx,
+                operation='create-database',
+                database_name='test-db',
+            )
+
+            # Verify that the result is the expected response
+            assert result == expected_response
+            assert handler.allow_write is True
+            assert handler.allow_sensitive_data_access is True
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_update_no_write_access(
+        self, handler, mock_ctx
+    ):
+        """Test that update table operation is not allowed without write access."""
+        # Call the method with a write operation
+        result = await handler.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='update-table',
+            database_name='test-db',
+            table_name='test-table',
+            table_input={'Name': 'test-table'},
+        )
+
+        # Verify that the result is an error response
+        assert result.isError is True
+        assert 'not allowed without write access' in result.content[0].text
+        assert result.database_name == 'test-db'
+        assert result.table_name == ''
+        assert result.operation == 'update-table'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_search_tables_no_write_access(
+        self, handler, mock_ctx
+    ):
+        """Test that search tables operation is allowed without write access."""
+        # Mock the search_tables method to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.tables = []
+        expected_response.search_text = 'test'
+        expected_response.count = 0
+        expected_response.operation = 'search-tables'
+        handler.data_catalog_table_manager.search_tables.return_value = expected_response
+
+        # Call the method with a read operation
+        result = await handler.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='search-tables',
+            database_name='test-db',
+            search_text='test',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert result.isError is False
+        assert handler.data_catalog_table_manager.search_tables.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_list_tables_no_write_access(
+        self, handler, mock_ctx
+    ):
+        """Test that list tables operation is allowed without write access."""
+        # Mock the list_tables method to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.tables = []
+        expected_response.count = 0
+        expected_response.operation = 'list-tables'
+        handler.data_catalog_table_manager.list_tables.return_value = expected_response
+
+        # Call the method with a read operation
+        result = await handler.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='list-tables',
+            database_name='test-db',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert result.isError is False
+        assert handler.data_catalog_table_manager.list_tables.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_list_connections_no_write_access(
+        self, handler, mock_ctx
+    ):
+        """Test that list connections operation is allowed without write access."""
+        # Mock the list_connections method to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.connections = []
+        expected_response.count = 0
+        expected_response.operation = 'list-connections'
+        handler.data_catalog_manager.list_connections.return_value = expected_response
+
+        # Call the method with a read operation
+        result = await handler.manage_aws_glue_data_catalog_connections(
+            mock_ctx,
+            operation='list-connections',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert result.isError is False
+        assert handler.data_catalog_manager.list_connections.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_get_partition_no_write_access(
+        self, handler, mock_ctx
+    ):
+        """Test that get partition operation is allowed without write access."""
+        # Mock the get_partition method to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.table_name = 'test-table'
+        expected_response.partition_values = ['2023']
+        expected_response.operation = 'get-partition'
+        handler.data_catalog_manager.get_partition.return_value = expected_response
+
+        # Call the method with a read operation
+        result = await handler.manage_aws_glue_data_catalog_partitions(
+            mock_ctx,
+            operation='get-partition',
+            database_name='test-db',
+            table_name='test-table',
+            partition_values=['2023'],
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert result.isError is False
+        assert handler.data_catalog_manager.get_partition.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_get_catalog_no_write_access(
+        self, handler, mock_ctx
+    ):
+        """Test that get catalog operation is allowed without write access."""
+        # Mock the get_catalog method to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.catalog_id = 'test-catalog'
+        expected_response.operation = 'get-catalog'
+        handler.data_catalog_manager.get_catalog.return_value = expected_response
+
+        # Call the method with a read operation
+        result = await handler.manage_aws_glue_data_catalog(
+            mock_ctx,
+            operation='get-catalog',
+            catalog_id='test-catalog',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert result.isError is False
+        assert handler.data_catalog_manager.get_catalog.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_exception_handling_general(
+        self, handler, mock_ctx
+    ):
+        """Test general exception handling in manage_aws_glue_data_catalog_tables."""
+        # Mock the get_table method to raise a general exception
+        handler.data_catalog_table_manager.get_table.side_effect = Exception(
+            'General test exception'
+        )
+
+        # Call the method
+        result = await handler.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='get-table',
+            database_name='test-db',
+            table_name='test-table',
+        )
+
+        # Verify that the result is an error response
+        assert result.isError is True
+        assert (
+            'Error in manage_aws_glue_data_catalog_tables: General test exception'
+            in result.content[0].text
+        )
+        assert result.database_name == 'test-db'
+        assert result.table_name == ''
+        assert result.operation == 'get-table'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_exception_handling_general(
+        self, handler, mock_ctx
+    ):
+        """Test general exception handling in manage_aws_glue_data_catalog_connections."""
+        # Mock the get_connection method to raise a general exception
+        handler.data_catalog_manager.get_connection.side_effect = Exception(
+            'General test exception'
+        )
+
+        # Call the method
+        result = await handler.manage_aws_glue_data_catalog_connections(
+            mock_ctx,
+            operation='get',
+            connection_name='test-connection',
+        )
+
+        # Verify that the result is an error response
+        assert result.isError is True
+        assert (
+            'Error in manage_aws_glue_data_catalog_connections: General test exception'
+            in result.content[0].text
+        )
+        assert result.connection_name == ''
+        assert result.operation == 'get'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_exception_handling_general(
+        self, handler, mock_ctx
+    ):
+        """Test general exception handling in manage_aws_glue_data_catalog_partitions."""
+        # Mock the get_partition method to raise a general exception
+        handler.data_catalog_manager.get_partition.side_effect = Exception(
+            'General test exception'
+        )
+
+        # Call the method
+        result = await handler.manage_aws_glue_data_catalog_partitions(
+            mock_ctx,
+            operation='get-partition',
+            database_name='test-db',
+            table_name='test-table',
+            partition_values=['2023'],
+        )
+
+        # Verify that the result is an error response
+        assert result.isError is True
+        assert (
+            'Error in manage_aws_glue_data_catalog_partitions: General test exception'
+            in result.content[0].text
+        )
+        assert result.database_name == 'test-db'
+        assert result.table_name == 'test-table'
+        assert result.partition_values == []
+        assert result.operation == 'get-partition'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_exception_handling_general(
+        self, handler, mock_ctx
+    ):
+        """Test general exception handling in manage_aws_glue_data_catalog."""
+        # Mock the get_catalog method to raise a general exception
+        handler.data_catalog_manager.get_catalog.side_effect = Exception('General test exception')
+
+        # Call the method
+        result = await handler.manage_aws_glue_data_catalog(
+            mock_ctx,
+            operation='get-catalog',
+            catalog_id='test-catalog',
+        )
+
+        # Verify that the result is an error response
+        assert result.isError is True
+        assert (
+            'Error in manage_aws_glue_data_catalog: General test exception'
+            in result.content[0].text
+        )
+        assert result.catalog_id == 'test-catalog'
+        assert result.operation == 'get-catalog'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_databases_error_response_for_other_operations(
+        self, handler, mock_ctx
+    ):
+        """Test that an error response is returned for operations not explicitly handled."""
+        # Set write access to true to bypass the "not allowed without write access" check
+        handler.allow_write = True
+
+        # Call the method with an operation that doesn't match any of the explicit cases
+        result = await handler.manage_aws_glue_data_catalog_databases(
+            mock_ctx,
+            operation='unknown-operation',
+            database_name='test-db',
+        )
+
+        # Verify that the result is an error response
+        assert result.isError is True
+        assert 'Invalid operation' in result.content[0].text
+        assert result.database_name == ''
+        assert result.description == ''
+        assert result.location_uri == ''
+        assert result.parameters == {}
+        assert result.creation_time == ''
+        assert result.operation == 'get-database'
+        assert result.catalog_id == ''
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_databases_with_none_parameters(
+        self, handler_with_write_access, mock_ctx, mock_database_manager
+    ):
+        """Test that the handler works correctly with None parameters."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.operation = 'create'
+        mock_database_manager.create_database.return_value = expected_response
+
+        # Call the method with None parameters
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_databases(
+            mock_ctx,
+            operation='create-database',
+            database_name='test-db',
+            description=None,
+            location_uri=None,
+            parameters=None,
+            catalog_id=None,
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_database_manager.create_database.assert_called_once_with(
+            ctx=mock_ctx,
+            database_name='test-db',
+            description=None,
+            location_uri=None,
+            parameters=None,
+            catalog_id=None,
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_with_none_parameters(
+        self, handler_with_write_access, mock_ctx, mock_table_manager
+    ):
+        """Test that the handler works correctly with None parameters."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.table_name = 'test-table'
+        expected_response.operation = 'create-table'
+        mock_table_manager.create_table.return_value = expected_response
+
+        # Call the method with None parameters
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='create-table',
+            database_name='test-db',
+            table_name='test-table',
+            table_input={'Name': 'test-table'},
+            catalog_id=None,
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_table_manager.create_table.assert_called_once_with(
+            ctx=mock_ctx,
+            database_name='test-db',
+            table_name='test-table',
+            table_input={'Name': 'test-table'},
+            catalog_id=None,
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_with_none_parameters(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test that the handler works correctly with None parameters."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.connection_name = 'test-connection'
+        expected_response.operation = 'create-connection'
+        mock_catalog_manager.create_connection.return_value = expected_response
+
+        # Call the method with None parameters
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+            mock_ctx,
+            operation='create-connection',
+            connection_name='test-connection',
+            connection_input={'ConnectionType': 'JDBC'},
+            catalog_id=None,
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.create_connection.assert_called_once_with(
+            ctx=mock_ctx,
+            connection_name='test-connection',
+            connection_input={'ConnectionType': 'JDBC'},
+            catalog_id=None,
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_with_none_parameters(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test that the handler works correctly with None parameters."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.table_name = 'test-table'
+        expected_response.partition_values = ['2023']
+        expected_response.operation = 'create-partition'
+        mock_catalog_manager.create_partition.return_value = expected_response
+
+        # Call the method with None parameters
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+            mock_ctx,
+            operation='create-partition',
+            database_name='test-db',
+            table_name='test-table',
+            partition_values=['2023'],
+            partition_input={'StorageDescriptor': {'Location': 's3://bucket/path/2023'}},
+            catalog_id=None,
+            max_results=None,
+            expression=None,
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.create_partition.assert_called_once_with(
+            ctx=mock_ctx,
+            database_name='test-db',
+            table_name='test-table',
+            partition_values=['2023'],
+            partition_input={'StorageDescriptor': {'Location': 's3://bucket/path/2023'}},
+            catalog_id=None,
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_with_none_parameters(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test that the handler works correctly with None parameters."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.catalog_id = 'test-catalog'
+        expected_response.operation = 'create-catalog'
+        mock_catalog_manager.create_catalog.return_value = expected_response
+
+        # Call the method with None parameters
+        result = await handler_with_write_access.manage_aws_glue_data_catalog(
+            mock_ctx,
+            operation='create-catalog',
+            catalog_id='test-catalog',
+            catalog_input={'Description': 'Test catalog'},
+            import_source=None,
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.create_catalog.assert_called_once_with(
+            ctx=mock_ctx,
+            catalog_name='test-catalog',
+            catalog_input={'Description': 'Test catalog'},
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_missing_database_name(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that missing database_name parameter raises a ValueError."""
+        # Mock the get_table method to raise the expected ValueError
+        handler_with_write_access.data_catalog_table_manager.get_table.side_effect = ValueError(
+            'database_name is required for get-table operation'
+        )
+
+        # Call the method without database_name
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+                mock_ctx,
+                operation='get-table',
+                table_name='test-table',
+            )
+
+        # Verify that the correct error message is raised
+        assert 'database_name is required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_missing_database_name(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that missing database_name parameter raises a ValueError."""
+        # Mock the get_partition method to raise the expected ValueError
+        handler_with_write_access.data_catalog_manager.get_partition.side_effect = ValueError(
+            'database_name is required for get-partition operation'
+        )
+
+        # Call the method without database_name
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+                mock_ctx,
+                operation='get-partition',
+                table_name='test-table',
+                partition_values=['2023'],
+            )
+
+        # Verify that the correct error message is raised
+        assert 'database_name is required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_missing_table_name(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that missing table_name parameter raises a ValueError."""
+        # Mock the get_partition method to raise the expected ValueError
+        handler_with_write_access.data_catalog_manager.get_partition.side_effect = ValueError(
+            'table_name is required for get-partition operation'
+        )
+
+        # Call the method without table_name
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+                mock_ctx,
+                operation='get-partition',
+                database_name='test-db',
+                partition_values=['2023'],
+            )
+
+        # Verify that the correct error message is raised
+        assert 'table_name is required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_update_with_catalog_id(
+        self, handler_with_write_access, mock_ctx, mock_table_manager
+    ):
+        """Test updating a table with a catalog ID."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.table_name = 'test-table'
+        expected_response.operation = 'update-table'
+        mock_table_manager.update_table.return_value = expected_response
+
+        # Call the method with a catalog ID
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='update-table',
+            database_name='test-db',
+            table_name='test-table',
+            table_input={'Name': 'test-table'},
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_table_manager.update_table.assert_called_once_with(
+            ctx=mock_ctx,
+            database_name='test-db',
+            table_name='test-table',
+            table_input={'Name': 'test-table'},
+            catalog_id='123456789012',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_update_with_catalog_id(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test updating a connection with a catalog ID."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.connection_name = 'test-connection'
+        expected_response.operation = 'update-connection'
+        expected_response.catalog_id = '123456789012'
+        mock_catalog_manager.update_connection.return_value = expected_response
+
+        # Call the method with a catalog ID
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+            mock_ctx,
+            operation='update-connection',
+            connection_name='test-connection',
+            connection_input={'ConnectionType': 'JDBC'},
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.update_connection.assert_called_once_with(
+            ctx=mock_ctx,
+            connection_name='test-connection',
+            connection_input={'ConnectionType': 'JDBC'},
+            catalog_id='123456789012',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert result.catalog_id == '123456789012'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_update_with_catalog_id(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test updating a partition with a catalog ID."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.table_name = 'test-table'
+        expected_response.partition_values = ['2023']
+        expected_response.operation = 'update-partition'
+        mock_catalog_manager.update_partition.return_value = expected_response
+
+        # Call the method with a catalog ID
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+            mock_ctx,
+            operation='update-partition',
+            database_name='test-db',
+            table_name='test-table',
+            partition_values=['2023'],
+            partition_input={'StorageDescriptor': {'Location': 's3://bucket/path/2023'}},
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.update_partition.assert_called_once_with(
+            ctx=mock_ctx,
+            database_name='test-db',
+            table_name='test-table',
+            partition_values=['2023'],
+            partition_input={'StorageDescriptor': {'Location': 's3://bucket/path/2023'}},
+            catalog_id='123456789012',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_delete_with_catalog_id(
+        self, handler_with_write_access, mock_ctx, mock_table_manager
+    ):
+        """Test deleting a table with a catalog ID."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.table_name = 'test-table'
+        expected_response.operation = 'delete-table'
+        mock_table_manager.delete_table.return_value = expected_response
+
+        # Call the method with a catalog ID
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='delete-table',
+            database_name='test-db',
+            table_name='test-table',
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_table_manager.delete_table.assert_called_once_with(
+            ctx=mock_ctx,
+            database_name='test-db',
+            table_name='test-table',
+            catalog_id='123456789012',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_delete_with_catalog_id(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test deleting a connection with a catalog ID."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.connection_name = 'test-connection'
+        expected_response.operation = 'delete-connection'
+        expected_response.catalog_id = '123456789012'
+        mock_catalog_manager.delete_connection.return_value = expected_response
+
+        # Call the method with a catalog ID
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+            mock_ctx,
+            operation='delete-connection',
+            connection_name='test-connection',
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.delete_connection.assert_called_once_with(
+            ctx=mock_ctx,
+            connection_name='test-connection',
+            catalog_id='123456789012',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert result.catalog_id == '123456789012'
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_delete_with_catalog_id(
+        self, handler_with_write_access, mock_ctx, mock_catalog_manager
+    ):
+        """Test deleting a partition with a catalog ID."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.database_name = 'test-db'
+        expected_response.table_name = 'test-table'
+        expected_response.partition_values = ['2023']
+        expected_response.operation = 'delete-partition'
+        mock_catalog_manager.delete_partition.return_value = expected_response
+
+        # Call the method with a catalog ID
+        result = await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+            mock_ctx,
+            operation='delete-partition',
+            database_name='test-db',
+            table_name='test-table',
+            partition_values=['2023'],
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.delete_partition.assert_called_once_with(
+            ctx=mock_ctx,
+            database_name='test-db',
+            table_name='test-table',
+            partition_values=['2023'],
+            catalog_id='123456789012',
+        )
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+
+    # Additional tests to increase coverage for specific lines
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_with_max_results(
+        self, handler, mock_ctx, mock_table_manager
+    ):
+        """Test listing tables with max_results parameter."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.tables = [{'Name': 'test-table1'}, {'Name': 'test-table2'}]
+        expected_response.count = 2
+        expected_response.operation = 'list-tables'
+        mock_table_manager.list_tables.return_value = expected_response
+
+        # Call the method with max_results
+        result = await handler.manage_aws_glue_data_catalog_tables(
+            mock_ctx,
+            operation='list-tables',
+            database_name='test-db',
+            max_results=10,
+        )
+
+        # Verify that the method was called with the correct parameters
+        assert mock_table_manager.list_tables.call_count == 1
+        assert mock_table_manager.list_tables.call_args[1]['max_results'] == 10
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert len(result.tables) == 2
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_databases_create_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that create database operation with missing required parameters raises a ValueError."""
+        # Mock the ValueError that should be raised
+        with patch.object(
+            handler_with_write_access.data_catalog_database_manager,
+            'create_database',
+            side_effect=ValueError('database_name is required for create-database operation'),
+        ):
+            # Call the method without database_name
+            with pytest.raises(ValueError) as excinfo:
+                await handler_with_write_access.manage_aws_glue_data_catalog_databases(
+                    mock_ctx, operation='create-database'
+                )
+
+        # Verify that the correct error message is raised
+        assert 'database_name is required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_create_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that create table operation with missing required parameters raises a ValueError."""
+        # Call the method without table_name
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+                mock_ctx, operation='create-table', database_name='test-db', table_name=None
+            )
+
+        # Verify that the correct error message is raised
+        assert 'table_name and table_input are required' in str(excinfo.value)
+
+        # Call the method without table_input
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+                mock_ctx,
+                operation='create-table',
+                database_name='test-db',
+                table_name='test-table',
+                table_input=None,
+            )
+
+        # Verify that the correct error message is raised
+        assert 'table_name and table_input are required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_delete_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that delete table operation with missing required parameters raises a ValueError."""
+        # Call the method without table_name
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+                mock_ctx, operation='delete-table', database_name='test-db', table_name=None
+            )
+
+        # Verify that the correct error message is raised
+        assert 'table_name is required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_get_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that get table operation with missing required parameters raises a ValueError."""
+        # Call the method without table_name
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+                mock_ctx, operation='get-table', database_name='test-db', table_name=None
+            )
+
+        # Verify that the correct error message is raised
+        assert 'table_name is required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_tables_update_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that update table operation with missing required parameters raises a ValueError."""
+        # Call the method without table_name
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+                mock_ctx, operation='update-table', database_name='test-db', table_name=None
+            )
+
+        # Verify that the correct error message is raised
+        assert 'table_name and table_input are required' in str(excinfo.value)
+
+        # Call the method without table_input
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_tables(
+                mock_ctx,
+                operation='update-table',
+                database_name='test-db',
+                table_name='test-table',
+                table_input=None,
+            )
+
+        # Verify that the correct error message is raised
+        assert 'table_name and table_input are required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_create_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that create connection operation with missing required parameters raises a ValueError."""
+        # Call the method without connection_name
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+                mock_ctx, operation='create-connection', connection_name=None
+            )
+
+        # Verify that the correct error message is raised
+        assert 'connection_name and connection_input are required' in str(excinfo.value)
+
+        # Call the method without connection_input
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+                mock_ctx,
+                operation='create-connection',
+                connection_name='test-connection',
+                connection_input=None,
+            )
+
+        # Verify that the correct error message is raised
+        assert 'connection_name and connection_input are required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_delete_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that delete connection operation with missing required parameters raises a ValueError."""
+        # Call the method without connection_name
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+                mock_ctx, operation='delete-connection', connection_name=None
+            )
+
+        # Verify that the correct error message is raised
+        assert 'connection_name is required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_get_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that get connection operation with missing required parameters raises a ValueError."""
+        # Call the method without connection_name
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+                mock_ctx, operation='get-connection', connection_name=None
+            )
+
+        # Verify that the correct error message is raised
+        assert 'connection_name is required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_update_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that update connection operation with missing required parameters raises a ValueError."""
+        # Call the method without connection_name
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+                mock_ctx, operation='update-connection', connection_name=None
+            )
+
+        # Verify that the correct error message is raised
+        assert 'connection_name and connection_input are required' in str(excinfo.value)
+
+        # Call the method without connection_input
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_connections(
+                mock_ctx,
+                operation='update-connection',
+                connection_name='test-connection',
+                connection_input=None,
+            )
+
+        # Verify that the correct error message is raised
+        assert 'connection_name and connection_input are required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_create_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that create partition operation with missing required parameters raises a ValueError."""
+        # Call the method without partition_values
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+                mock_ctx,
+                operation='create-partition',
+                database_name='test-db',
+                table_name='test-table',
+                partition_values=None,
+            )
+
+        # Verify that the correct error message is raised
+        assert 'partition_values and partition_input are required' in str(excinfo.value)
+
+        # Call the method without partition_input
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+                mock_ctx,
+                operation='create-partition',
+                database_name='test-db',
+                table_name='test-table',
+                partition_values=['2023'],
+                partition_input=None,
+            )
+
+        # Verify that the correct error message is raised
+        assert 'partition_values and partition_input are required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_delete_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that delete partition operation with missing required parameters raises a ValueError."""
+        # Call the method without partition_values
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+                mock_ctx,
+                operation='delete-partition',
+                database_name='test-db',
+                table_name='test-table',
+                partition_values=None,
+            )
+
+        # Verify that the correct error message is raised
+        assert 'partition_values is required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_get_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that get partition operation with missing required parameters raises a ValueError."""
+        # Call the method without partition_values
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+                mock_ctx,
+                operation='get-partition',
+                database_name='test-db',
+                table_name='test-table',
+                partition_values=None,
+            )
+
+        # Verify that the correct error message is raised
+        assert 'partition_values is required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_update_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that update partition operation with missing required parameters raises a ValueError."""
+        # Call the method without partition_values
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+                mock_ctx,
+                operation='update-partition',
+                database_name='test-db',
+                table_name='test-table',
+                partition_values=None,
+            )
+
+        # Verify that the correct error message is raised
+        assert 'partition_values and partition_input are required' in str(excinfo.value)
+
+        # Call the method without partition_input
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog_partitions(
+                mock_ctx,
+                operation='update-partition',
+                database_name='test-db',
+                table_name='test-table',
+                partition_values=['2023'],
+                partition_input=None,
+            )
+
+        # Verify that the correct error message is raised
+        assert 'partition_values and partition_input are required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_create_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that create catalog operation with missing required parameters raises a ValueError."""
+        # Call the method without catalog_id
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog(
+                mock_ctx, operation='create-catalog', catalog_id=None
+            )
+
+        # Verify that the correct error message is raised
+        assert 'catalog_id and catalog_input are required' in str(excinfo.value)
+
+        # Call the method without catalog_input
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog(
+                mock_ctx, operation='create-catalog', catalog_id='test-catalog', catalog_input=None
+            )
+
+        # Verify that the correct error message is raised
+        assert 'catalog_id and catalog_input are required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_delete_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that delete catalog operation with missing required parameters raises a ValueError."""
+        # Call the method without catalog_id
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog(
+                mock_ctx, operation='delete-catalog', catalog_id=None
+            )
+
+        # Verify that the correct error message is raised
+        assert 'catalog_id is required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_get_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that get catalog operation with missing required parameters raises a ValueError."""
+        # Call the method without catalog_id
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog(
+                mock_ctx, operation='get-catalog', catalog_id=None
+            )
+
+        # Verify that the correct error message is raised
+        assert 'catalog_id is required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_import_missing_required_params(
+        self, handler_with_write_access, mock_ctx
+    ):
+        """Test that import catalog operation with missing required parameters raises a ValueError."""
+        # Call the method without catalog_id
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog(
+                mock_ctx, operation='import-catalog-to-glue', catalog_id=None
+            )
+
+        # Verify that the correct error message is raised
+        assert 'catalog_id and import_source are required' in str(excinfo.value)
+
+        # Call the method without import_source
+        with pytest.raises(ValueError) as excinfo:
+            await handler_with_write_access.manage_aws_glue_data_catalog(
+                mock_ctx,
+                operation='import-catalog-to-glue',
+                catalog_id='test-catalog',
+                import_source=None,
+            )
+
+        # Verify that the correct error message is raised
+        assert 'catalog_id and import_source are required' in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_partitions_list_with_all_parameters(
+        self, handler, mock_ctx, mock_catalog_manager
+    ):
+        """Test listing partitions with all parameters including next_token."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.partitions = [{'Values': ['2023', '01']}, {'Values': ['2023', '02']}]
+        expected_response.count = 2
+        expected_response.next_token = 'next-token-value'
+        expected_response.operation = 'list-partitions'
+        mock_catalog_manager.list_partitions.return_value = expected_response
+
+        # Call the method with all parameters
+        result = await handler.manage_aws_glue_data_catalog_partitions(
+            mock_ctx,
+            operation='list-partitions',
+            database_name='test-db',
+            table_name='test-table',
+            max_results=10,
+            expression="year='2023'",
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.list_partitions.assert_called_once()
+        assert mock_catalog_manager.list_partitions.call_args[1]['database_name'] == 'test-db'
+        assert mock_catalog_manager.list_partitions.call_args[1]['table_name'] == 'test-table'
+        assert mock_catalog_manager.list_partitions.call_args[1]['max_results'] == 10
+        assert mock_catalog_manager.list_partitions.call_args[1]['expression'] == "year='2023'"
+        assert mock_catalog_manager.list_partitions.call_args[1]['catalog_id'] == '123456789012'
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert len(result.partitions) == 2
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_list_with_max_results(
+        self, handler, mock_ctx, mock_catalog_manager
+    ):
+        """Test listing connections with max_results parameter."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.connections = [
+            {'Name': 'connection1', 'ConnectionType': 'JDBC'},
+            {'Name': 'connection2', 'ConnectionType': 'KAFKA'},
+        ]
+        expected_response.count = 2
+        expected_response.operation = 'list-connections'
+        mock_catalog_manager.list_connections.return_value = expected_response
+
+        # Call the method with max_results
+        result = await handler.manage_aws_glue_data_catalog_connections(
+            mock_ctx,
+            operation='list-connections',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.list_connections.assert_called_once()
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert len(result.connections) == 2
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_list_with_all_parameters(
+        self, handler, mock_ctx, mock_catalog_manager
+    ):
+        """Test listing connections with all parameters."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.connections = [
+            {'Name': 'connection1', 'ConnectionType': 'JDBC'},
+            {'Name': 'connection2', 'ConnectionType': 'KAFKA'},
+        ]
+        expected_response.count = 2
+        expected_response.next_token = 'next-token-value'
+        expected_response.operation = 'list-connections'
+        mock_catalog_manager.list_connections.return_value = expected_response
+
+        # Call the method with all parameters
+        result = await handler.manage_aws_glue_data_catalog_connections(
+            mock_ctx,
+            operation='list-connections',
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.list_connections.assert_called_once()
+        assert mock_catalog_manager.list_connections.call_args[1]['catalog_id'] == '123456789012'
+
+        # Verify that the result is the expected response
+        assert result == expected_response
+        assert len(result.connections) == 2
+
+    @pytest.mark.asyncio
+    async def test_manage_aws_glue_data_catalog_connections_get_with_all_parameters(
+        self, handler, mock_ctx, mock_catalog_manager
+    ):
+        """Test getting a connection with all parameters."""
+        # Setup the mock to return a response
+        expected_response = MagicMock()
+        expected_response.isError = False
+        expected_response.content = []
+        expected_response.connection_name = 'test-connection'
+        expected_response.connection_type = 'JDBC'
+        expected_response.connection_properties = {
+            'JDBC_CONNECTION_URL': 'jdbc:mysql://test-host:3306/test-db'
+        }
+        expected_response.operation = 'get'
+        mock_catalog_manager.get_connection.return_value = expected_response
+
+        # Call the method with all parameters
+        result = await handler.manage_aws_glue_data_catalog_connections(
+            mock_ctx,
+            operation='get',
+            connection_name='test-connection',
+            catalog_id='123456789012',
+        )
+
+        # Verify that the method was called with the correct parameters
+        mock_catalog_manager.get_connection.assert_called_once()
+        assert (
+            mock_catalog_manager.get_connection.call_args[1]['connection_name']
+            == 'test-connection'
+        )
+        assert mock_catalog_manager.get_connection.call_args[1]['catalog_id'] == '123456789012'
+
+        # Verify that the result is the expected response
+        assert result == expected_response


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

> Added more unit tests

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
