### PR TITLE
fix(dataprocessing-mcp-server): Add unit and update readme for AWS Glue Interactive Session and AWS Glue Workflows mcp tools

### DIFF
--- a/src/dataprocessing-mcp-server/README.md
+++ b/src/dataprocessing-mcp-server/README.md
@@ -10,6 +10,8 @@ Integrating the DataProcessing MCP server into AI code assistants transforms dat
 ### AWS Glue Integration
 
 * Data Catalog Management: Enables users to explore, create, and manage databases, tables, and partitions through natural language requests, automatically translating them into appropriate AWS Glue Data Catalog operations.
+* Interactive Sessions: Provides interactive development environment for Spark and Ray workloads, enabling data exploration, debugging, and iterative development through managed Jupyter-like sessions.
+* Workflows and Triggers: Orchestrates complex ETL activities through visual workflows and automated triggers, supporting scheduled, conditional, and event-based execution patterns.
 
 
 ## Prerequisites
@@ -215,6 +217,20 @@ Specifies the AWS region where Glue,EMR clusters or Athena are managed, which wi
 | manage_aws_glue_partitions | Manage AWS Glue Data Catalog partitions | create-partition, delete-partition, get-partition, list-partitions, update-partition | --allow-write flag for create/delete/update operations, database and table must exist, appropriate AWS permissions |
 | manage_aws_glue_catalog | Manage AWS Glue Data Catalog | create-catalog, delete-catalog, get-catalog, list-catalogs, import-catalog-to-glue | --allow-write flag for create/delete/import operations, appropriate AWS permissions |
 
+### Glue Interactive Sessions Handler Tools
+
+| Tool Name | Description | Key Operations | Requirements |
+|-----------|-------------|----------------|--------------|
+| manage_aws_glue_sessions | Manage AWS Glue Interactive Sessions for Spark and Ray workloads | create-session, delete-session, get-session, list-sessions, stop-session | --allow-write flag for create/delete/stop operations, appropriate AWS permissions |
+| manage_aws_glue_statements | Execute and manage code statements within Glue Interactive Sessions | run-statement, cancel-statement, get-statement, list-statements | --allow-write flag for run/cancel operations, active session required |
+
+
+### Glue Workflows and Triggers Handler Tools
+
+| Tool Name | Description | Key Operations | Requirements |
+|-----------|-------------|----------------|--------------|
+| manage_aws_glue_workflows | Orchestrate complex ETL activities through visual workflows | create-workflow, delete-workflow, get-workflow, list-workflows, start-workflow-run | --allow-write flag for create/delete/start operations, appropriate AWS permissions |
+| manage_aws_glue_triggers | Automate workflow and job execution with scheduled or event-based triggers | create-trigger, delete-trigger, get-trigger, get-triggers, start-trigger, stop-trigger | --allow-write flag for create/delete/start/stop operations, appropriate AWS permissions |
 
 ## Version
 

--- a/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/handlers/glue/glue_interactive_sessions_handler.py
+++ b/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/handlers/glue/glue_interactive_sessions_handler.py
@@ -258,8 +258,8 @@ class GlueInteractiveSessionsHandler:
                 resource_tags = AwsHelper.prepare_resource_tags('GlueSession')
 
                 # Merge user-provided tags with MCP tags
-                if tags:
-                    merged_tags = tags.copy()
+                if tags and isinstance(tags, dict):
+                    merged_tags = dict(tags)
                     merged_tags.update(resource_tags)
                     create_params['Tags'] = merged_tags
                 else:

--- a/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/server.py
+++ b/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/server.py
@@ -39,6 +39,12 @@ from awslabs.dataprocessing_mcp_server.handlers.glue.glue_commons_handler import
 from awslabs.dataprocessing_mcp_server.handlers.glue.glue_etl_handler import (
     GlueEtlJobsHandler,
 )
+from awslabs.dataprocessing_mcp_server.handlers.glue.glue_interactive_sessions_handler import (
+    GlueInteractiveSessionsHandler,
+)
+from awslabs.dataprocessing_mcp_server.handlers.glue.glue_worklows_handler import (
+    GlueWorkflowAndTriggerHandler,
+)
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
 
@@ -124,6 +130,31 @@ It enables you to create, manage, and monitor data processing workflows.
 4. List steps: `manage_aws_emr_ec2_steps(operation='list-steps', cluster_id='j-123ABC456DEF')`
 5. List steps with filters: `manage_aws_emr_ec2_steps(operation='list-steps', cluster_id='j-123ABC456DEF', step_states=['RUNNING', 'COMPLETED'])`
 
+### Glue Interactive Sessions
+1. Create a session: `manage_aws_glue_sessions(operation='create-session', session_id='my-spark-session', role='arn:aws:iam::123456789012:role/GlueInteractiveSessionRole', command={'Name': 'glueetl', 'PythonVersion': '3'}, glue_version='4.0')`
+2. Get session details: `manage_aws_glue_sessions(operation='get-session', session_id='my-spark-session')`
+3. List all sessions: `manage_aws_glue_sessions(operation='list-sessions')`
+4. Stop a session: `manage_aws_glue_sessions(operation='stop-session', session_id='my-spark-session')`
+5. Delete a session: `manage_aws_glue_sessions(operation='delete-session', session_id='my-spark-session')`
+6. Run a statement: `manage_aws_glue_statements(operation='run-statement', session_id='my-spark-session', code='df = spark.read.csv("s3://bucket/data.csv", header=True); df.show(5)')`
+7. Get statement results: `manage_aws_glue_statements(operation='get-statement', session_id='my-spark-session', statement_id=1)`
+8. List statements in session: `manage_aws_glue_statements(operation='list-statements', session_id='my-spark-session')`
+9. Cancel a running statement: `manage_aws_glue_statements(operation='cancel-statement', session_id='my-spark-session', statement_id=1)`
+
+### Glue Workflows and Triggers
+1. Create a workflow: `manage_aws_glue_workflows(operation='create-workflow', workflow_name='my-etl-workflow', workflow_definition={'Description': 'ETL workflow for daily data processing', 'DefaultRunProperties': {'ENV': 'production'}, 'MaxConcurrentRuns': 1})`
+2. Get workflow details: `manage_aws_glue_workflows(operation='get-workflow', workflow_name='my-etl-workflow')`
+3. List all workflows: `manage_aws_glue_workflows(operation='list-workflows')`
+4. Start a workflow run: `manage_aws_glue_workflows(operation='start-workflow-run', workflow_name='my-etl-workflow', workflow_definition={'run_properties': {'EXECUTION_DATE': '2023-06-19'}})`
+5. Delete a workflow: `manage_aws_glue_workflows(operation='delete-workflow', workflow_name='my-etl-workflow')`
+6. Create a scheduled trigger: `manage_aws_glue_triggers(operation='create-trigger', trigger_name='daily-etl-trigger', trigger_definition={'Type': 'SCHEDULED', 'Schedule': 'cron(0 12 * * ? *)', 'Actions': [{'JobName': 'process-daily-data'}], 'Description': 'Trigger for daily ETL job', 'StartOnCreation': True})`
+7. Create a conditional trigger: `manage_aws_glue_triggers(operation='create-trigger', trigger_name='data-arrival-trigger', trigger_definition={'Type': 'CONDITIONAL', 'Actions': [{'JobName': 'process-new-data'}], 'Predicate': {'Conditions': [{'LogicalOperator': 'EQUALS', 'JobName': 'crawl-new-data', 'State': 'SUCCEEDED'}]}})`
+8. Get trigger details: `manage_aws_glue_triggers(operation='get-trigger', trigger_name='daily-etl-trigger')`
+9. List all triggers: `manage_aws_glue_triggers(operation='get-triggers')`
+10. Start a trigger: `manage_aws_glue_triggers(operation='start-trigger', trigger_name='daily-etl-trigger')`
+11. Stop a trigger: `manage_aws_glue_triggers(operation='stop-trigger', trigger_name='daily-etl-trigger')`
+12. Delete a trigger: `manage_aws_glue_triggers(operation='delete-trigger', trigger_name='daily-etl-trigger')`
+
 """
 
 SERVER_DEPENDENCIES = [
@@ -208,6 +239,16 @@ def main():
         allow_sensitive_data_access=allow_sensitive_data_access,
     )
     EMREc2StepsHandler(
+        mcp,
+        allow_write=allow_write,
+        allow_sensitive_data_access=allow_sensitive_data_access,
+    )
+    GlueInteractiveSessionsHandler(
+        mcp,
+        allow_write=allow_write,
+        allow_sensitive_data_access=allow_sensitive_data_access,
+    )
+    GlueWorkflowAndTriggerHandler(
         mcp,
         allow_write=allow_write,
         allow_sensitive_data_access=allow_sensitive_data_access,

--- a/src/dataprocessing-mcp-server/tests/handlers/glue/test_glue_interactive_sessions_handler.py
+++ b/src/dataprocessing-mcp-server/tests/handlers/glue/test_glue_interactive_sessions_handler.py
@@ -932,3 +932,836 @@ async def test_missing_statement_id_for_get_statement(mock_create_client):
             mock_ctx, operation='get-statement', session_id='test-session', statement_id=None
         )
     assert 'statement_id is required' in str(excinfo.value)
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_delete_session_no_write_access(mock_create_client):
+    """Test delete session without write access."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=False)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx, operation='delete-session', session_id='test-session'
+    )
+
+    assert result.isError
+    assert 'Operation delete-session is not allowed without write access' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_stop_session_no_write_access(mock_create_client):
+    """Test stop session without write access."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=False)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx, operation='stop-session', session_id='test-session'
+    )
+
+    assert result.isError
+    assert 'Operation stop-session is not allowed without write access' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_session_with_all_optional_params(mock_prepare_tags, mock_create_client):
+    """Test create session with all optional parameters."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.create_session.return_value = {
+        'Session': {'Id': 'test-session', 'Status': 'PROVISIONING'}
+    }
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation='create-session',
+        session_id='test-session',
+        role='arn:aws:iam::123456789012:role/GlueRole',
+        command={'Name': 'glueetl'},
+        description='Test description',
+        timeout=120,
+        idle_timeout=60,
+        default_arguments={'--arg': 'value'},
+        connections={'Connections': ['conn1']},
+        max_capacity=2.0,
+        number_of_workers=4,
+        worker_type='G.2X',
+        security_configuration='test-config',
+        glue_version='4.0',
+        request_origin='test-origin',
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.create_session.call_args
+    assert kwargs['Description'] == 'Test description'
+    assert kwargs['Timeout'] == 120
+    assert kwargs['IdleTimeout'] == 60
+    assert kwargs['DefaultArguments'] == {'--arg': 'value'}
+    assert kwargs['Connections'] == {'Connections': ['conn1']}
+    assert kwargs['MaxCapacity'] == 2.0
+    assert kwargs['NumberOfWorkers'] == 4
+    assert kwargs['WorkerType'] == 'G.2X'
+    assert kwargs['SecurityConfiguration'] == 'test-config'
+    assert kwargs['GlueVersion'] == '4.0'
+    assert kwargs['RequestOrigin'] == 'test-origin'
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_session_without_user_tags(mock_prepare_tags, mock_create_client):
+    """Test create session without user-provided tags."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.create_session.return_value = {
+        'Session': {'Id': 'test-session', 'Status': 'PROVISIONING'}
+    }
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation='create-session',
+        session_id='test-session',
+        role='arn:aws:iam::123456789012:role/GlueRole',
+        command={'Name': 'glueetl'},
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.create_session.call_args
+    assert kwargs['Tags'] == {'ManagedBy': 'MCP'}
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+async def test_delete_session_client_error(mock_get_account_id, mock_get_region, mock_create_client):
+    """Test delete session with non-EntityNotFoundException ClientError."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_session.side_effect = ClientError(
+        {'Error': {'Code': 'AccessDeniedException', 'Message': 'Access denied'}}, 'get_session'
+    )
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx, operation='delete-session', session_id='test-session'
+    )
+    
+    assert result.isError
+    assert 'Error in manage_aws_glue_sessions' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_get_session_with_request_origin(mock_create_client):
+    """Test get session with request_origin."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_session.return_value = {
+        'Session': {'Id': 'test-session', 'Status': 'READY'}
+    }
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation='get-session',
+        session_id='test-session',
+        request_origin='test-origin',
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.get_session.call_args
+    assert kwargs['RequestOrigin'] == 'test-origin'
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_list_sessions_with_tags(mock_create_client):
+    """Test list sessions with tags parameter."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.list_sessions.return_value = {
+        'Sessions': [{'Id': 'session1'}],
+        'Ids': ['session1'],
+    }
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation='list-sessions',
+        tags={'Environment': 'Test'},
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.list_sessions.call_args
+    assert kwargs['Tags'] == {'Environment': 'Test'}
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+async def test_stop_session_client_error(mock_get_account_id, mock_get_region, mock_create_client):
+    """Test stop session with non-EntityNotFoundException ClientError."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_session.side_effect = ClientError(
+        {'Error': {'Code': 'AccessDeniedException', 'Message': 'Access denied'}}, 'get_session'
+    )
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx, operation='stop-session', session_id='test-session'
+    )
+    
+    assert result.isError
+    assert 'Error in manage_aws_glue_sessions' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed')
+async def test_stop_session_with_request_origin(
+    mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client
+):
+    """Test stop session with request_origin."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_is_mcp_managed.return_value = True
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_session.return_value = {
+        'Session': {'Id': 'test-session', 'Tags': {'ManagedBy': 'MCP'}}
+    }
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation='stop-session',
+        session_id='test-session',
+        request_origin='test-origin',
+    )
+
+    assert not result.isError
+    get_args, get_kwargs = mock_glue_client.get_session.call_args
+    assert get_kwargs['RequestOrigin'] == 'test-origin'
+    stop_args, stop_kwargs = mock_glue_client.stop_session.call_args
+    assert stop_kwargs['RequestOrigin'] == 'test-origin'
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_invalid_session_operation(mock_create_client):
+    """Test invalid session operation."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx, operation='invalid-operation', session_id='test-session'
+    )
+
+    assert result.isError
+    assert 'Invalid operation: invalid-operation' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_cancel_statement_no_write_access(mock_create_client):
+    """Test cancel statement without write access."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=False)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx, operation='cancel-statement', session_id='test-session', statement_id=1
+    )
+
+    assert result.isError
+    assert 'Operation cancel-statement is not allowed without write access' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_run_statement_with_request_origin(mock_create_client):
+    """Test run statement with request_origin."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.run_statement.return_value = {'Id': 1}
+
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx,
+        operation='run-statement',
+        session_id='test-session',
+        code='print("hello")',
+        request_origin='test-origin',
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.run_statement.call_args
+    assert kwargs['RequestOrigin'] == 'test-origin'
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_cancel_statement_with_request_origin(mock_create_client):
+    """Test cancel statement with request_origin."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx,
+        operation='cancel-statement',
+        session_id='test-session',
+        statement_id=1,
+        request_origin='test-origin',
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.cancel_statement.call_args
+    assert kwargs['RequestOrigin'] == 'test-origin'
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_get_statement_with_request_origin(mock_create_client):
+    """Test get statement with request_origin."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_statement.return_value = {
+        'Statement': {'Id': 1, 'State': 'AVAILABLE'}
+    }
+
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx,
+        operation='get-statement',
+        session_id='test-session',
+        statement_id=1,
+        request_origin='test-origin',
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.get_statement.call_args
+    assert kwargs['RequestOrigin'] == 'test-origin'
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_list_statements_with_pagination(mock_create_client):
+    """Test list statements with max_results and next_token."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.list_statements.return_value = {
+        'Statements': [{'Id': 1}],
+        'NextToken': 'next-token',
+    }
+
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx,
+        operation='list-statements',
+        session_id='test-session',
+        max_results=10,
+        next_token='token',
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.list_statements.call_args
+    assert kwargs['MaxResults'] == '10'
+    assert kwargs['NextToken'] == 'token'
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_list_statements_with_request_origin(mock_create_client):
+    """Test list statements with request_origin."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.list_statements.return_value = {
+        'Statements': [{'Id': 1}],
+    }
+
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx,
+        operation='list-statements',
+        session_id='test-session',
+        request_origin='test-origin',
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.list_statements.call_args
+    assert kwargs['RequestOrigin'] == 'test-origin'
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_invalid_statement_operation(mock_create_client):
+    """Test invalid statement operation."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx, operation='invalid-operation', session_id='test-session', statement_id=1
+    )
+
+    assert result.isError
+    assert 'Invalid operation: invalid-operation' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_statements_general_exception(mock_create_client):
+    """Test general exception handling in statements."""
+    mock_glue_client = MagicMock()
+    mock_glue_client.get_statement.side_effect = Exception('Test exception')
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx, operation='get-statement', session_id='test-session', statement_id=1
+    )
+
+    assert result.isError
+    assert 'Error in manage_aws_glue_statements: Test exception' in result.content[0].text
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed')
+async def test_stop_session_not_mcp_managed(
+    mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client
+):
+    """Test stop session when session is not MCP managed."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_is_mcp_managed.return_value = False
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_session.return_value = {
+        'Session': {'Id': 'test-session', 'Tags': {}}
+    }
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx, operation='stop-session', session_id='test-session'
+    )
+
+    assert result.isError
+    assert 'Cannot stop session test-session - it is not managed by the MCP server' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+async def test_stop_session_not_found(mock_get_account_id, mock_get_region, mock_create_client):
+    """Test stop session when session is not found."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_session.side_effect = ClientError(
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Session not found'}}, 'get_session'
+    )
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx, operation='stop-session', session_id='test-session'
+    )
+
+    assert result.isError
+    assert 'Session test-session not found' in result.content[0].text
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_session_individual_params(mock_prepare_tags, mock_create_client):
+    """Test create session with individual optional parameters."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.create_session.return_value = {
+        'Session': {'Id': 'test-session', 'Status': 'PROVISIONING'}
+    }
+
+    # Test with description only
+    await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation='create-session',
+        session_id='test-session',
+        role='arn:aws:iam::123456789012:role/GlueRole',
+        command={'Name': 'glueetl'},
+        description='Test description',
+    )
+
+    # Test with timeout only
+    await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation='create-session',
+        session_id='test-session',
+        role='arn:aws:iam::123456789012:role/GlueRole',
+        command={'Name': 'glueetl'},
+        timeout=120,
+    )
+
+    # Test with idle_timeout only
+    await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation='create-session',
+        session_id='test-session',
+        role='arn:aws:iam::123456789012:role/GlueRole',
+        command={'Name': 'glueetl'},
+        idle_timeout=60,
+    )
+
+    # Test with default_arguments only
+    await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation='create-session',
+        session_id='test-session',
+        role='arn:aws:iam::123456789012:role/GlueRole',
+        command={'Name': 'glueetl'},
+        default_arguments={'--arg': 'value'},
+    )
+
+    # Test with connections only
+    await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation='create-session',
+        session_id='test-session',
+        role='arn:aws:iam::123456789012:role/GlueRole',
+        command={'Name': 'glueetl'},
+        connections={'Connections': ['conn1']},
+    )
+
+    # Test with max_capacity only
+    await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation='create-session',
+        session_id='test-session',
+        role='arn:aws:iam::123456789012:role/GlueRole',
+        command={'Name': 'glueetl'},
+        max_capacity=2.0,
+    )
+
+    # Test with number_of_workers only
+    await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation='create-session',
+        session_id='test-session',
+        role='arn:aws:iam::123456789012:role/GlueRole',
+        command={'Name': 'glueetl'},
+        number_of_workers=4,
+    )
+
+    # Test with worker_type only
+    await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation='create-session',
+        session_id='test-session',
+        role='arn:aws:iam::123456789012:role/GlueRole',
+        command={'Name': 'glueetl'},
+        worker_type='G.2X',
+    )
+
+    # Test with security_configuration only
+    await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation='create-session',
+        session_id='test-session',
+        role='arn:aws:iam::123456789012:role/GlueRole',
+        command={'Name': 'glueetl'},
+        security_configuration='test-config',
+    )
+
+    # Test with glue_version only
+    await handler.manage_aws_glue_sessions(
+        mock_ctx,
+        operation='create-session',
+        session_id='test-session',
+        role='arn:aws:iam::123456789012:role/GlueRole',
+        command={'Name': 'glueetl'},
+        glue_version='4.0',
+    )
+
+    assert mock_glue_client.create_session.call_count == 10
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+async def test_delete_session_entity_not_found(mock_get_account_id, mock_get_region, mock_create_client):
+    """Test delete session when session is not found."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_session.side_effect = ClientError(
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Session not found'}}, 'get_session'
+    )
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx, operation='delete-session', session_id='test-session'
+    )
+
+    assert result.isError
+    assert 'Session test-session not found' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_get_session_without_request_origin(mock_create_client):
+    """Test get session without request_origin."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_session.return_value = {
+        'Session': {'Id': 'test-session', 'Status': 'READY'}
+    }
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx, operation='get-session', session_id='test-session'
+    )
+
+    assert not result.isError
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_list_sessions_without_optional_params(mock_create_client):
+    """Test list sessions without optional parameters."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.list_sessions.return_value = {
+        'Sessions': [{'Id': 'session1'}],
+        'Ids': ['session1'],
+    }
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx, operation='list-sessions'
+    )
+
+    assert not result.isError
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed')
+async def test_stop_session_without_request_origin(
+    mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client
+):
+    """Test stop session without request_origin."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_is_mcp_managed.return_value = True
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_session.return_value = {
+        'Session': {'Id': 'test-session', 'Tags': {'ManagedBy': 'MCP'}}
+    }
+
+    result = await handler.manage_aws_glue_sessions(
+        mock_ctx, operation='stop-session', session_id='test-session'
+    )
+
+    assert not result.isError
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_run_statement_without_request_origin(mock_create_client):
+    """Test run statement without request_origin."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.run_statement.return_value = {'Id': 1}
+
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx, operation='run-statement', session_id='test-session', code='print("hello")'
+    )
+
+    assert not result.isError
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_get_statement_without_request_origin(mock_create_client):
+    """Test get statement without request_origin."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_statement.return_value = {
+        'Statement': {'Id': 1, 'State': 'AVAILABLE'}
+    }
+
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx, operation='get-statement', session_id='test-session', statement_id=1
+    )
+
+    assert not result.isError
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_list_statements_without_optional_params(mock_create_client):
+    """Test list statements without optional parameters."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.list_statements.return_value = {
+        'Statements': [{'Id': 1}],
+    }
+
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx, operation='list-statements', session_id='test-session'
+    )
+
+    assert not result.isError
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_cancel_statement_without_request_origin(mock_create_client):
+    """Test cancel statement without request_origin."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueInteractiveSessionsHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    result = await handler.manage_aws_glue_statements(
+        mock_ctx, operation='cancel-statement', session_id='test-session', statement_id=1
+    )
+
+    assert not result.isError

--- a/src/dataprocessing-mcp-server/tests/handlers/glue/test_glue_interactive_sessions_handler.py
+++ b/src/dataprocessing-mcp-server/tests/handlers/glue/test_glue_interactive_sessions_handler.py
@@ -933,6 +933,7 @@ async def test_missing_statement_id_for_get_statement(mock_create_client):
         )
     assert 'statement_id is required' in str(excinfo.value)
 
+
 @pytest.mark.asyncio
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 async def test_delete_session_no_write_access(mock_create_client):
@@ -1056,7 +1057,9 @@ async def test_create_session_without_user_tags(mock_prepare_tags, mock_create_c
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
-async def test_delete_session_client_error(mock_get_account_id, mock_get_region, mock_create_client):
+async def test_delete_session_client_error(
+    mock_get_account_id, mock_get_region, mock_create_client
+):
     """Test delete session with non-EntityNotFoundException ClientError."""
     mock_glue_client = MagicMock()
     mock_create_client.return_value = mock_glue_client
@@ -1074,7 +1077,7 @@ async def test_delete_session_client_error(mock_get_account_id, mock_get_region,
     result = await handler.manage_aws_glue_sessions(
         mock_ctx, operation='delete-session', session_id='test-session'
     )
-    
+
     assert result.isError
     assert 'Error in manage_aws_glue_sessions' in result.content[0].text
 
@@ -1155,7 +1158,7 @@ async def test_stop_session_client_error(mock_get_account_id, mock_get_region, m
     result = await handler.manage_aws_glue_sessions(
         mock_ctx, operation='stop-session', session_id='test-session'
     )
-    
+
     assert result.isError
     assert 'Error in manage_aws_glue_sessions' in result.content[0].text
 
@@ -1232,7 +1235,9 @@ async def test_cancel_statement_no_write_access(mock_create_client):
     )
 
     assert result.isError
-    assert 'Operation cancel-statement is not allowed without write access' in result.content[0].text
+    assert (
+        'Operation cancel-statement is not allowed without write access' in result.content[0].text
+    )
 
 
 @pytest.mark.asyncio
@@ -1296,9 +1301,7 @@ async def test_get_statement_with_request_origin(mock_create_client):
     handler.glue_client = mock_glue_client
     mock_ctx = MagicMock(spec=Context)
 
-    mock_glue_client.get_statement.return_value = {
-        'Statement': {'Id': 1, 'State': 'AVAILABLE'}
-    }
+    mock_glue_client.get_statement.return_value = {'Statement': {'Id': 1, 'State': 'AVAILABLE'}}
 
     result = await handler.manage_aws_glue_statements(
         mock_ctx,
@@ -1408,6 +1411,7 @@ async def test_statements_general_exception(mock_create_client):
     assert result.isError
     assert 'Error in manage_aws_glue_statements: Test exception' in result.content[0].text
 
+
 @pytest.mark.asyncio
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
@@ -1427,16 +1431,17 @@ async def test_stop_session_not_mcp_managed(
     handler.glue_client = mock_glue_client
     mock_ctx = MagicMock(spec=Context)
 
-    mock_glue_client.get_session.return_value = {
-        'Session': {'Id': 'test-session', 'Tags': {}}
-    }
+    mock_glue_client.get_session.return_value = {'Session': {'Id': 'test-session', 'Tags': {}}}
 
     result = await handler.manage_aws_glue_sessions(
         mock_ctx, operation='stop-session', session_id='test-session'
     )
 
     assert result.isError
-    assert 'Cannot stop session test-session - it is not managed by the MCP server' in result.content[0].text
+    assert (
+        'Cannot stop session test-session - it is not managed by the MCP server'
+        in result.content[0].text
+    )
 
 
 @pytest.mark.asyncio
@@ -1455,7 +1460,8 @@ async def test_stop_session_not_found(mock_get_account_id, mock_get_region, mock
     mock_ctx = MagicMock(spec=Context)
 
     mock_glue_client.get_session.side_effect = ClientError(
-        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Session not found'}}, 'get_session'
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Session not found'}},
+        'get_session',
     )
 
     result = await handler.manage_aws_glue_sessions(
@@ -1464,6 +1470,7 @@ async def test_stop_session_not_found(mock_get_account_id, mock_get_region, mock
 
     assert result.isError
     assert 'Session test-session not found' in result.content[0].text
+
 
 @pytest.mark.asyncio
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
@@ -1583,11 +1590,15 @@ async def test_create_session_individual_params(mock_prepare_tags, mock_create_c
     )
 
     assert mock_glue_client.create_session.call_count == 10
+
+
 @pytest.mark.asyncio
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
-async def test_delete_session_entity_not_found(mock_get_account_id, mock_get_region, mock_create_client):
+async def test_delete_session_entity_not_found(
+    mock_get_account_id, mock_get_region, mock_create_client
+):
     """Test delete session when session is not found."""
     mock_glue_client = MagicMock()
     mock_create_client.return_value = mock_glue_client
@@ -1599,7 +1610,8 @@ async def test_delete_session_entity_not_found(mock_get_account_id, mock_get_reg
     mock_ctx = MagicMock(spec=Context)
 
     mock_glue_client.get_session.side_effect = ClientError(
-        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Session not found'}}, 'get_session'
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Session not found'}},
+        'get_session',
     )
 
     result = await handler.manage_aws_glue_sessions(
@@ -1648,9 +1660,7 @@ async def test_list_sessions_without_optional_params(mock_create_client):
         'Ids': ['session1'],
     }
 
-    result = await handler.manage_aws_glue_sessions(
-        mock_ctx, operation='list-sessions'
-    )
+    result = await handler.manage_aws_glue_sessions(mock_ctx, operation='list-sessions')
 
     assert not result.isError
 
@@ -1716,9 +1726,7 @@ async def test_get_statement_without_request_origin(mock_create_client):
     handler.glue_client = mock_glue_client
     mock_ctx = MagicMock(spec=Context)
 
-    mock_glue_client.get_statement.return_value = {
-        'Statement': {'Id': 1, 'State': 'AVAILABLE'}
-    }
+    mock_glue_client.get_statement.return_value = {'Statement': {'Id': 1, 'State': 'AVAILABLE'}}
 
     result = await handler.manage_aws_glue_statements(
         mock_ctx, operation='get-statement', session_id='test-session', statement_id=1

--- a/src/dataprocessing-mcp-server/tests/handlers/glue/test_glue_workflows_handler.py
+++ b/src/dataprocessing-mcp-server/tests/handlers/glue/test_glue_workflows_handler.py
@@ -703,7 +703,8 @@ async def test_start_workflow_run_no_write_access(mock_create_client):
     assert len(result.content) == 1
     assert result.content[0].type == 'text'
     assert (
-        'Operation start-workflow-run is not allowed without write access' in result.content[0].text
+        'Operation start-workflow-run is not allowed without write access'
+        in result.content[0].text
     )
 
     # Verify that start_workflow_run was NOT called
@@ -822,7 +823,7 @@ async def test_manage_aws_glue_workflows_general_exception(mock_create_client):
     """Test handling of general exceptions in manage_aws_glue_workflows."""
     # Create a mock Glue client that raises an exception
     mock_glue_client = MagicMock()
-    mock_glue_client.get_workflow.side_effect = Exception("Test exception")
+    mock_glue_client.get_workflow.side_effect = Exception('Test exception')
     mock_create_client.return_value = mock_glue_client
 
     # Create a mock MCP server
@@ -1614,6 +1615,8 @@ async def test_trigger_not_found(mock_create_client):
 
     # Verify that delete_trigger was NOT called
     mock_glue_client.delete_trigger.assert_not_called()
+
+
 @pytest.mark.asyncio
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
@@ -1644,7 +1647,9 @@ async def test_create_workflow_without_description(mock_prepare_tags, mock_creat
 @pytest.mark.asyncio
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
-async def test_create_workflow_without_default_run_properties(mock_prepare_tags, mock_create_client):
+async def test_create_workflow_without_default_run_properties(
+    mock_prepare_tags, mock_create_client
+):
     """Test creating workflow without DefaultRunProperties parameter."""
     mock_glue_client = MagicMock()
     mock_create_client.return_value = mock_glue_client
@@ -1699,7 +1704,9 @@ async def test_create_workflow_without_max_concurrent_runs(mock_prepare_tags, mo
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
-async def test_delete_workflow_client_error(mock_get_account_id, mock_get_region, mock_create_client):
+async def test_delete_workflow_client_error(
+    mock_get_account_id, mock_get_region, mock_create_client
+):
     """Test delete workflow with non-EntityNotFoundException ClientError."""
     mock_glue_client = MagicMock()
     mock_create_client.return_value = mock_glue_client
@@ -1717,7 +1724,7 @@ async def test_delete_workflow_client_error(mock_get_account_id, mock_get_region
     result = await handler.manage_aws_glue_workflows(
         mock_ctx, operation='delete-workflow', workflow_name='test-workflow'
     )
-    
+
     assert result.isError
     assert 'Error in manage_aws_glue_workflows' in result.content[0].text
 
@@ -1760,9 +1767,7 @@ async def test_list_workflows_without_pagination(mock_create_client):
 
     mock_glue_client.list_workflows.return_value = {'Workflows': ['workflow1']}
 
-    result = await handler.manage_aws_glue_workflows(
-        mock_ctx, operation='list-workflows'
-    )
+    result = await handler.manage_aws_glue_workflows(mock_ctx, operation='list-workflows')
 
     assert not result.isError
 
@@ -1771,7 +1776,9 @@ async def test_list_workflows_without_pagination(mock_create_client):
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
-async def test_start_workflow_run_client_error(mock_get_account_id, mock_get_region, mock_create_client):
+async def test_start_workflow_run_client_error(
+    mock_get_account_id, mock_get_region, mock_create_client
+):
     """Test start workflow run with non-EntityNotFoundException ClientError."""
     mock_glue_client = MagicMock()
     mock_create_client.return_value = mock_glue_client
@@ -1789,7 +1796,7 @@ async def test_start_workflow_run_client_error(mock_get_account_id, mock_get_reg
     result = await handler.manage_aws_glue_workflows(
         mock_ctx, operation='start-workflow-run', workflow_name='test-workflow'
     )
-    
+
     assert result.isError
     assert 'Error in manage_aws_glue_workflows' in result.content[0].text
 
@@ -1954,7 +1961,9 @@ async def test_create_trigger_without_user_tags(mock_prepare_tags, mock_create_c
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
-async def test_delete_trigger_client_error(mock_get_account_id, mock_get_region, mock_create_client):
+async def test_delete_trigger_client_error(
+    mock_get_account_id, mock_get_region, mock_create_client
+):
     """Test delete trigger with non-EntityNotFoundException ClientError."""
     mock_glue_client = MagicMock()
     mock_create_client.return_value = mock_glue_client
@@ -1972,7 +1981,7 @@ async def test_delete_trigger_client_error(mock_get_account_id, mock_get_region,
     result = await handler.manage_aws_glue_triggers(
         mock_ctx, operation='delete-trigger', trigger_name='test-trigger'
     )
-    
+
     assert result.isError
     assert 'Error in manage_aws_glue_triggers' in result.content[0].text
 
@@ -1990,9 +1999,7 @@ async def test_get_triggers_without_pagination(mock_create_client):
 
     mock_glue_client.get_triggers.return_value = {'Triggers': []}
 
-    result = await handler.manage_aws_glue_triggers(
-        mock_ctx, operation='get-triggers'
-    )
+    result = await handler.manage_aws_glue_triggers(mock_ctx, operation='get-triggers')
 
     assert not result.isError
 
@@ -2001,7 +2008,9 @@ async def test_get_triggers_without_pagination(mock_create_client):
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
-async def test_start_trigger_client_error(mock_get_account_id, mock_get_region, mock_create_client):
+async def test_start_trigger_client_error(
+    mock_get_account_id, mock_get_region, mock_create_client
+):
     """Test start trigger with non-EntityNotFoundException ClientError."""
     mock_glue_client = MagicMock()
     mock_create_client.return_value = mock_glue_client
@@ -2019,7 +2028,7 @@ async def test_start_trigger_client_error(mock_get_account_id, mock_get_region, 
     result = await handler.manage_aws_glue_triggers(
         mock_ctx, operation='start-trigger', trigger_name='test-trigger'
     )
-    
+
     assert result.isError
     assert 'Error in manage_aws_glue_triggers' in result.content[0].text
 
@@ -2046,7 +2055,7 @@ async def test_stop_trigger_client_error(mock_get_account_id, mock_get_region, m
     result = await handler.manage_aws_glue_triggers(
         mock_ctx, operation='stop-trigger', trigger_name='test-trigger'
     )
-    
+
     assert result.isError
     assert 'Error in manage_aws_glue_triggers' in result.content[0].text
 
@@ -2067,7 +2076,9 @@ async def test_triggers_no_write_access_fallback(mock_create_client):
     )
 
     assert result.isError
-    assert 'Operation unknown-operation is not allowed without write access' in result.content[0].text
+    assert (
+        'Operation unknown-operation is not allowed without write access' in result.content[0].text
+    )
 
 
 @pytest.mark.asyncio
@@ -2088,6 +2099,8 @@ async def test_triggers_general_exception(mock_create_client):
 
     assert result.isError
     assert 'Error in manage_aws_glue_triggers: Test exception' in result.content[0].text
+
+
 @pytest.mark.asyncio
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
@@ -2119,7 +2132,9 @@ async def test_create_workflow_with_description_only(mock_prepare_tags, mock_cre
 @pytest.mark.asyncio
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
-async def test_create_workflow_with_default_run_properties_only(mock_prepare_tags, mock_create_client):
+async def test_create_workflow_with_default_run_properties_only(
+    mock_prepare_tags, mock_create_client
+):
     """Test creating workflow with DefaultRunProperties parameter only."""
     mock_glue_client = MagicMock()
     mock_create_client.return_value = mock_glue_client
@@ -2147,7 +2162,9 @@ async def test_create_workflow_with_default_run_properties_only(mock_prepare_tag
 @pytest.mark.asyncio
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
-async def test_create_workflow_with_max_concurrent_runs_only(mock_prepare_tags, mock_create_client):
+async def test_create_workflow_with_max_concurrent_runs_only(
+    mock_prepare_tags, mock_create_client
+):
     """Test creating workflow with MaxConcurrentRuns parameter only."""
     mock_glue_client = MagicMock()
     mock_create_client.return_value = mock_glue_client
@@ -2175,7 +2192,9 @@ async def test_create_workflow_with_max_concurrent_runs_only(mock_prepare_tags, 
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
-async def test_delete_workflow_entity_not_found(mock_get_account_id, mock_get_region, mock_create_client):
+async def test_delete_workflow_entity_not_found(
+    mock_get_account_id, mock_get_region, mock_create_client
+):
     """Test delete workflow when workflow is not found."""
     mock_glue_client = MagicMock()
     mock_create_client.return_value = mock_glue_client
@@ -2187,7 +2206,8 @@ async def test_delete_workflow_entity_not_found(mock_get_account_id, mock_get_re
     mock_ctx = MagicMock(spec=Context)
 
     mock_glue_client.get_workflow.side_effect = ClientError(
-        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Workflow not found'}}, 'get_workflow'
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Workflow not found'}},
+        'get_workflow',
     )
 
     result = await handler.manage_aws_glue_workflows(
@@ -2220,7 +2240,7 @@ async def test_get_workflow_with_include_graph_true(mock_create_client):
 
     assert not result.isError
     args, kwargs = mock_glue_client.get_workflow.call_args
-    assert kwargs['IncludeGraph'] == True
+    assert kwargs['IncludeGraph']
 
 
 @pytest.mark.asyncio
@@ -2271,7 +2291,9 @@ async def test_list_workflows_with_next_token(mock_create_client):
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
-async def test_start_workflow_run_entity_not_found(mock_get_account_id, mock_get_region, mock_create_client):
+async def test_start_workflow_run_entity_not_found(
+    mock_get_account_id, mock_get_region, mock_create_client
+):
     """Test start workflow run when workflow is not found."""
     mock_glue_client = MagicMock()
     mock_create_client.return_value = mock_glue_client
@@ -2283,7 +2305,8 @@ async def test_start_workflow_run_entity_not_found(mock_get_account_id, mock_get
     mock_ctx = MagicMock(spec=Context)
 
     mock_glue_client.get_workflow.side_effect = ClientError(
-        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Workflow not found'}}, 'get_workflow'
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Workflow not found'}},
+        'get_workflow',
     )
 
     result = await handler.manage_aws_glue_workflows(
@@ -2334,7 +2357,9 @@ async def test_start_workflow_run_with_run_properties(
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
-async def test_delete_trigger_entity_not_found(mock_get_account_id, mock_get_region, mock_create_client):
+async def test_delete_trigger_entity_not_found(
+    mock_get_account_id, mock_get_region, mock_create_client
+):
     """Test delete trigger when trigger is not found."""
     mock_glue_client = MagicMock()
     mock_create_client.return_value = mock_glue_client
@@ -2346,7 +2371,8 @@ async def test_delete_trigger_entity_not_found(mock_get_account_id, mock_get_reg
     mock_ctx = MagicMock(spec=Context)
 
     mock_glue_client.get_trigger.side_effect = ClientError(
-        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Trigger not found'}}, 'get_trigger'
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Trigger not found'}},
+        'get_trigger',
     )
 
     result = await handler.manage_aws_glue_triggers(
@@ -2405,7 +2431,9 @@ async def test_get_triggers_with_next_token(mock_create_client):
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
-async def test_start_trigger_entity_not_found(mock_get_account_id, mock_get_region, mock_create_client):
+async def test_start_trigger_entity_not_found(
+    mock_get_account_id, mock_get_region, mock_create_client
+):
     """Test start trigger when trigger is not found."""
     mock_glue_client = MagicMock()
     mock_create_client.return_value = mock_glue_client
@@ -2417,7 +2445,8 @@ async def test_start_trigger_entity_not_found(mock_get_account_id, mock_get_regi
     mock_ctx = MagicMock(spec=Context)
 
     mock_glue_client.get_trigger.side_effect = ClientError(
-        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Trigger not found'}}, 'get_trigger'
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Trigger not found'}},
+        'get_trigger',
     )
 
     result = await handler.manage_aws_glue_triggers(
@@ -2432,7 +2461,9 @@ async def test_start_trigger_entity_not_found(mock_get_account_id, mock_get_regi
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
-async def test_stop_trigger_entity_not_found(mock_get_account_id, mock_get_region, mock_create_client):
+async def test_stop_trigger_entity_not_found(
+    mock_get_account_id, mock_get_region, mock_create_client
+):
     """Test stop trigger when trigger is not found."""
     mock_glue_client = MagicMock()
     mock_create_client.return_value = mock_glue_client
@@ -2444,7 +2475,8 @@ async def test_stop_trigger_entity_not_found(mock_get_account_id, mock_get_regio
     mock_ctx = MagicMock(spec=Context)
 
     mock_glue_client.get_trigger.side_effect = ClientError(
-        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Trigger not found'}}, 'get_trigger'
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Trigger not found'}},
+        'get_trigger',
     )
 
     result = await handler.manage_aws_glue_triggers(

--- a/src/dataprocessing-mcp-server/tests/handlers/glue/test_glue_workflows_handler.py
+++ b/src/dataprocessing-mcp-server/tests/handlers/glue/test_glue_workflows_handler.py
@@ -112,6 +112,181 @@ async def test_create_workflow_success(
 
 @pytest.mark.asyncio
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_workflow_with_user_tags(mock_prepare_tags, mock_create_client):
+    """Test creating a workflow with user-provided tags."""
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+
+    # Mock the resource tags
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the create_workflow response
+    mock_glue_client.create_workflow.return_value = {'Name': 'test-workflow'}
+
+    # Call the manage_aws_glue_workflows method with create-workflow operation and user tags
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='create-workflow',
+        workflow_name='test-workflow',
+        workflow_definition={
+            'Description': 'Test workflow',
+            'Tags': {'Environment': 'Test', 'Project': 'UnitTest'},
+        },
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert result.workflow_name == 'test-workflow'
+
+    # Verify that create_workflow was called with merged tags
+    mock_glue_client.create_workflow.assert_called_once()
+    args, kwargs = mock_glue_client.create_workflow.call_args
+    assert kwargs['Tags'] == {'Environment': 'Test', 'Project': 'UnitTest', 'ManagedBy': 'MCP'}
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_workflow_with_only_description(mock_prepare_tags, mock_create_client):
+    """Test creating a workflow with only description parameter."""
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+
+    # Mock the resource tags
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the create_workflow response
+    mock_glue_client.create_workflow.return_value = {'Name': 'test-workflow'}
+
+    # Call the manage_aws_glue_workflows method with create-workflow operation and only description
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='create-workflow',
+        workflow_name='test-workflow',
+        workflow_definition={
+            'Description': 'Test workflow',
+        },
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert result.workflow_name == 'test-workflow'
+
+    # Verify that create_workflow was called with the correct parameters
+    mock_glue_client.create_workflow.assert_called_once()
+    args, kwargs = mock_glue_client.create_workflow.call_args
+    assert kwargs['Description'] == 'Test workflow'
+    assert 'DefaultRunProperties' not in kwargs
+    assert kwargs['Tags'] == {'ManagedBy': 'MCP'}
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_create_workflow_missing_parameters(mock_create_client):
+    """Test creating a workflow with missing required parameters."""
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Test missing workflow_definition
+    with pytest.raises(ValueError) as excinfo:
+        await handler.manage_aws_glue_workflows(
+            mock_ctx,
+            operation='create-workflow',
+            workflow_name='test-workflow',
+            workflow_definition=None,
+        )
+    assert 'workflow_name and workflow_definition are required' in str(excinfo.value)
+
+    # Test missing workflow_name
+    with pytest.raises(ValueError) as excinfo:
+        await handler.manage_aws_glue_workflows(
+            mock_ctx,
+            operation='create-workflow',
+            workflow_name=None,
+            workflow_definition={'Description': 'Test workflow'},
+        )
+    assert 'workflow_name and workflow_definition are required' in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_get_workflow_with_include_graph_false(mock_create_client):
+    """Test getting a workflow with include_graph parameter set to False."""
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_workflow response
+    mock_workflow_details = {
+        'Name': 'test-workflow',
+        'Description': 'Test workflow',
+        'CreatedOn': '2023-01-01T00:00:00Z',
+    }
+    mock_glue_client.get_workflow.return_value = {'Workflow': mock_workflow_details}
+
+    # Call the manage_aws_glue_workflows method with get-workflow operation and include_graph=False
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='get-workflow',
+        workflow_name='test-workflow',
+        workflow_definition={'include_graph': False},
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert result.workflow_name == 'test-workflow'
+    assert result.workflow_details == mock_workflow_details
+
+    # Verify that get_workflow was called without IncludeGraph parameter
+    mock_glue_client.get_workflow.assert_called_once_with(Name='test-workflow')
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 async def test_create_workflow_no_write_access(mock_create_client):
     # Create a mock Glue client
     mock_glue_client = MagicMock()
@@ -445,6 +620,235 @@ async def test_start_workflow_run_success(
 
 @pytest.mark.asyncio
 @patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed')
+async def test_start_workflow_run_not_mcp_managed(
+    mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client
+):
+    """Test starting a workflow run for a workflow that is not MCP managed."""
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+
+    # Mock the region and account ID
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+
+    # Mock the is_resource_mcp_managed to return False
+    mock_is_mcp_managed.return_value = False
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_workflow response
+    mock_glue_client.get_workflow.return_value = {
+        'Workflow': {'Name': 'test-workflow', 'Tags': {}}  # No MCP tags
+    }
+
+    # Call the manage_aws_glue_workflows method with start-workflow-run operation
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='start-workflow-run',
+        workflow_name='test-workflow',
+    )
+
+    # Verify the result indicates an error because the workflow is not MCP managed
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == 'text'
+    assert (
+        'Cannot start workflow run for test-workflow - it is not managed by the MCP server'
+        in result.content[0].text
+    )
+
+    # Verify that start_workflow_run was NOT called
+    mock_glue_client.start_workflow_run.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_start_workflow_run_no_write_access(mock_create_client):
+    """Test starting a workflow run without write access."""
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server without write access
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=False)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Call the manage_aws_glue_workflows method with start-workflow-run operation
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='start-workflow-run',
+        workflow_name='test-workflow',
+    )
+
+    # Verify the result indicates an error due to no write access
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == 'text'
+    assert (
+        'Operation start-workflow-run is not allowed without write access' in result.content[0].text
+    )
+
+    # Verify that start_workflow_run was NOT called
+    mock_glue_client.start_workflow_run.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed')
+async def test_start_workflow_run_not_found(
+    mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client
+):
+    """Test starting a workflow run for a workflow that doesn't exist."""
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+
+    # Mock the region and account ID
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_workflow to raise EntityNotFoundException
+    mock_glue_client.exceptions.EntityNotFoundException = ClientError(
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Workflow not found'}},
+        'get_workflow',
+    )
+    mock_glue_client.get_workflow.side_effect = mock_glue_client.exceptions.EntityNotFoundException
+
+    # Call the manage_aws_glue_workflows method with start-workflow-run operation
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='start-workflow-run',
+        workflow_name='test-workflow',
+    )
+
+    # Verify the result indicates an error because the workflow was not found
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == 'text'
+    assert 'Workflow test-workflow not found' in result.content[0].text
+
+    # Verify that start_workflow_run was NOT called
+    mock_glue_client.start_workflow_run.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed')
+async def test_start_workflow_run_without_run_properties(
+    mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client
+):
+    """Test starting a workflow run without run properties."""
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+
+    # Mock the region and account ID
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+
+    # Mock the is_resource_mcp_managed to return True
+    mock_is_mcp_managed.return_value = True
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the get_workflow response
+    mock_glue_client.get_workflow.return_value = {
+        'Workflow': {'Name': 'test-workflow', 'Tags': {'ManagedBy': 'MCP'}}
+    }
+
+    # Mock the start_workflow_run response
+    mock_glue_client.start_workflow_run.return_value = {'RunId': 'run-123'}
+
+    # Call the manage_aws_glue_workflows method with start-workflow-run operation without run_properties
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='start-workflow-run',
+        workflow_name='test-workflow',
+        workflow_definition={},  # Empty definition, no run_properties
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert result.workflow_name == 'test-workflow'
+    assert result.run_id == 'run-123'
+
+    # Verify that start_workflow_run was called with just the Name parameter
+    mock_glue_client.start_workflow_run.assert_called_once_with(Name='test-workflow')
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_manage_aws_glue_workflows_general_exception(mock_create_client):
+    """Test handling of general exceptions in manage_aws_glue_workflows."""
+    # Create a mock Glue client that raises an exception
+    mock_glue_client = MagicMock()
+    mock_glue_client.get_workflow.side_effect = Exception("Test exception")
+    mock_create_client.return_value = mock_glue_client
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Call the manage_aws_glue_workflows method with get-workflow operation
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx, operation='get-workflow', workflow_name='test-workflow'
+    )
+
+    # Verify the result indicates an error
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == 'text'
+    assert 'Error in manage_aws_glue_workflows: Test exception' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
 async def test_invalid_operation(mock_create_client):
     # Create a mock Glue client
     mock_glue_client = MagicMock()
@@ -571,6 +975,244 @@ async def test_create_trigger_success(mock_prepare_tags, mock_create_client):
     assert kwargs['Description'] == 'Test trigger'
     assert kwargs['StartOnCreation']
     assert kwargs['Tags'] == {'ManagedBy': 'MCP'}
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_trigger_with_user_tags(mock_prepare_tags, mock_create_client):
+    """Test creating a trigger with user-provided tags."""
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+
+    # Mock the resource tags
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the create_trigger response
+    mock_glue_client.create_trigger.return_value = {'Name': 'test-trigger'}
+
+    # Call the manage_aws_glue_triggers method with create-trigger operation and user tags
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation='create-trigger',
+        trigger_name='test-trigger',
+        trigger_definition={
+            'Type': 'SCHEDULED',
+            'Actions': [{'JobName': 'test-job'}],
+            'Tags': {'Environment': 'Test', 'Project': 'UnitTest'},
+        },
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert result.trigger_name == 'test-trigger'
+
+    # Verify that create_trigger was called with merged tags
+    mock_glue_client.create_trigger.assert_called_once()
+    args, kwargs = mock_glue_client.create_trigger.call_args
+    assert kwargs['Tags'] == {'Environment': 'Test', 'Project': 'UnitTest', 'ManagedBy': 'MCP'}
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_trigger_with_workflow_name(mock_prepare_tags, mock_create_client):
+    """Test creating a trigger with workflow_name parameter."""
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+
+    # Mock the resource tags
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the create_trigger response
+    mock_glue_client.create_trigger.return_value = {'Name': 'test-trigger'}
+
+    # Call the manage_aws_glue_triggers method with create-trigger operation and workflow_name
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation='create-trigger',
+        trigger_name='test-trigger',
+        trigger_definition={
+            'Type': 'SCHEDULED',
+            'Actions': [{'JobName': 'test-job'}],
+            'WorkflowName': 'test-workflow',
+        },
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert result.trigger_name == 'test-trigger'
+
+    # Verify that create_trigger was called with workflow_name
+    mock_glue_client.create_trigger.assert_called_once()
+    args, kwargs = mock_glue_client.create_trigger.call_args
+    assert kwargs['WorkflowName'] == 'test-workflow'
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_trigger_with_predicate(mock_prepare_tags, mock_create_client):
+    """Test creating a trigger with predicate parameter."""
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+
+    # Mock the resource tags
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the create_trigger response
+    mock_glue_client.create_trigger.return_value = {'Name': 'test-trigger'}
+
+    # Call the manage_aws_glue_triggers method with create-trigger operation and predicate
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation='create-trigger',
+        trigger_name='test-trigger',
+        trigger_definition={
+            'Type': 'CONDITIONAL',
+            'Actions': [{'JobName': 'test-job'}],
+            'Predicate': {
+                'Conditions': [
+                    {
+                        'LogicalOperator': 'EQUALS',
+                        'JobName': 'crawl-job',
+                        'State': 'SUCCEEDED',
+                    }
+                ]
+            },
+        },
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert result.trigger_name == 'test-trigger'
+
+    # Verify that create_trigger was called with predicate
+    mock_glue_client.create_trigger.assert_called_once()
+    args, kwargs = mock_glue_client.create_trigger.call_args
+    assert kwargs['Predicate']['Conditions'][0]['LogicalOperator'] == 'EQUALS'
+    assert kwargs['Predicate']['Conditions'][0]['JobName'] == 'crawl-job'
+    assert kwargs['Predicate']['Conditions'][0]['State'] == 'SUCCEEDED'
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_trigger_with_event_batching_condition(mock_prepare_tags, mock_create_client):
+    """Test creating a trigger with event_batching_condition parameter."""
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+
+    # Mock the resource tags
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Mock the create_trigger response
+    mock_glue_client.create_trigger.return_value = {'Name': 'test-trigger'}
+
+    # Call the manage_aws_glue_triggers method with create-trigger operation and event_batching_condition
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation='create-trigger',
+        trigger_name='test-trigger',
+        trigger_definition={
+            'Type': 'EVENT',
+            'Actions': [{'JobName': 'test-job'}],
+            'EventBatchingCondition': {'BatchSize': 5, 'BatchWindow': 900},
+        },
+    )
+
+    # Verify the result
+    assert not result.isError
+    assert result.trigger_name == 'test-trigger'
+
+    # Verify that create_trigger was called with event_batching_condition
+    mock_glue_client.create_trigger.assert_called_once()
+    args, kwargs = mock_glue_client.create_trigger.call_args
+    assert kwargs['EventBatchingCondition']['BatchSize'] == 5
+    assert kwargs['EventBatchingCondition']['BatchWindow'] == 900
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_create_trigger_missing_parameters(mock_create_client):
+    """Test creating a trigger with missing required parameters."""
+    # Create a mock Glue client
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+
+    # Create a mock MCP server
+    mock_mcp = MagicMock()
+
+    # Initialize the Glue Workflow handler with the mock MCP server
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+
+    # Create a mock context
+    mock_ctx = MagicMock(spec=Context)
+
+    # Test missing trigger_definition
+    with pytest.raises(ValueError) as excinfo:
+        await handler.manage_aws_glue_triggers(
+            mock_ctx,
+            operation='create-trigger',
+            trigger_name='test-trigger',
+            trigger_definition=None,
+        )
+    assert 'trigger_name and trigger_definition are required' in str(excinfo.value)
+
+    # Test missing trigger_name
+    with pytest.raises(ValueError) as excinfo:
+        await handler.manage_aws_glue_triggers(
+            mock_ctx,
+            operation='create-trigger',
+            trigger_name=None,
+            trigger_definition={'Type': 'SCHEDULED', 'Actions': [{'JobName': 'test-job'}]},
+        )
+    assert 'trigger_name and trigger_definition are required' in str(excinfo.value)
 
 
 @pytest.mark.asyncio
@@ -972,3 +1614,842 @@ async def test_trigger_not_found(mock_create_client):
 
     # Verify that delete_trigger was NOT called
     mock_glue_client.delete_trigger.assert_not_called()
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_workflow_without_description(mock_prepare_tags, mock_create_client):
+    """Test creating workflow without description parameter."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.create_workflow.return_value = {'Name': 'test-workflow'}
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='create-workflow',
+        workflow_name='test-workflow',
+        workflow_definition={},
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.create_workflow.call_args
+    assert 'Description' not in kwargs
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_workflow_without_default_run_properties(mock_prepare_tags, mock_create_client):
+    """Test creating workflow without DefaultRunProperties parameter."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.create_workflow.return_value = {'Name': 'test-workflow'}
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='create-workflow',
+        workflow_name='test-workflow',
+        workflow_definition={'Description': 'Test'},
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.create_workflow.call_args
+    assert 'DefaultRunProperties' not in kwargs
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_workflow_without_max_concurrent_runs(mock_prepare_tags, mock_create_client):
+    """Test creating workflow without MaxConcurrentRuns parameter."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.create_workflow.return_value = {'Name': 'test-workflow'}
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='create-workflow',
+        workflow_name='test-workflow',
+        workflow_definition={'Description': 'Test'},
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.create_workflow.call_args
+    assert 'MaxConcurrentRuns' not in kwargs
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+async def test_delete_workflow_client_error(mock_get_account_id, mock_get_region, mock_create_client):
+    """Test delete workflow with non-EntityNotFoundException ClientError."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_workflow.side_effect = ClientError(
+        {'Error': {'Code': 'AccessDeniedException', 'Message': 'Access denied'}}, 'get_workflow'
+    )
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx, operation='delete-workflow', workflow_name='test-workflow'
+    )
+    
+    assert result.isError
+    assert 'Error in manage_aws_glue_workflows' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_get_workflow_without_include_graph(mock_create_client):
+    """Test get workflow without include_graph parameter."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_workflow.return_value = {'Workflow': {'Name': 'test-workflow'}}
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='get-workflow',
+        workflow_name='test-workflow',
+        workflow_definition={},
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.get_workflow.call_args
+    assert 'IncludeGraph' not in kwargs
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_list_workflows_without_pagination(mock_create_client):
+    """Test list workflows without pagination parameters."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.list_workflows.return_value = {'Workflows': ['workflow1']}
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx, operation='list-workflows'
+    )
+
+    assert not result.isError
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+async def test_start_workflow_run_client_error(mock_get_account_id, mock_get_region, mock_create_client):
+    """Test start workflow run with non-EntityNotFoundException ClientError."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_workflow.side_effect = ClientError(
+        {'Error': {'Code': 'AccessDeniedException', 'Message': 'Access denied'}}, 'get_workflow'
+    )
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx, operation='start-workflow-run', workflow_name='test-workflow'
+    )
+    
+    assert result.isError
+    assert 'Error in manage_aws_glue_workflows' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed')
+async def test_start_workflow_run_without_run_properties_mcp_managed(
+    mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client
+):
+    """Test start workflow run without run_properties when workflow is MCP managed."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_is_mcp_managed.return_value = True
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_workflow.return_value = {
+        'Workflow': {'Name': 'test-workflow', 'Tags': {'ManagedBy': 'MCP'}}
+    }
+    mock_glue_client.start_workflow_run.return_value = {'RunId': 'run-123'}
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='start-workflow-run',
+        workflow_name='test-workflow',
+        workflow_definition={},
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.start_workflow_run.call_args
+    assert 'RunProperties' not in kwargs
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_trigger_individual_params(mock_prepare_tags, mock_create_client):
+    """Test create trigger with individual optional parameters."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.create_trigger.return_value = {'Name': 'test-trigger'}
+
+    # Test with WorkflowName
+    await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation='create-trigger',
+        trigger_name='test-trigger',
+        trigger_definition={
+            'Type': 'SCHEDULED',
+            'Actions': [{'JobName': 'test-job'}],
+            'WorkflowName': 'test-workflow',
+        },
+    )
+
+    # Test with Schedule
+    await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation='create-trigger',
+        trigger_name='test-trigger',
+        trigger_definition={
+            'Type': 'SCHEDULED',
+            'Actions': [{'JobName': 'test-job'}],
+            'Schedule': 'cron(0 12 * * ? *)',
+        },
+    )
+
+    # Test with Predicate
+    await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation='create-trigger',
+        trigger_name='test-trigger',
+        trigger_definition={
+            'Type': 'CONDITIONAL',
+            'Actions': [{'JobName': 'test-job'}],
+            'Predicate': {'Conditions': []},
+        },
+    )
+
+    # Test with Description
+    await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation='create-trigger',
+        trigger_name='test-trigger',
+        trigger_definition={
+            'Type': 'SCHEDULED',
+            'Actions': [{'JobName': 'test-job'}],
+            'Description': 'Test trigger',
+        },
+    )
+
+    # Test with StartOnCreation
+    await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation='create-trigger',
+        trigger_name='test-trigger',
+        trigger_definition={
+            'Type': 'SCHEDULED',
+            'Actions': [{'JobName': 'test-job'}],
+            'StartOnCreation': True,
+        },
+    )
+
+    # Test with EventBatchingCondition
+    await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation='create-trigger',
+        trigger_name='test-trigger',
+        trigger_definition={
+            'Type': 'EVENT',
+            'Actions': [{'JobName': 'test-job'}],
+            'EventBatchingCondition': {'BatchSize': 5},
+        },
+    )
+
+    assert mock_glue_client.create_trigger.call_count == 6
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_trigger_without_user_tags(mock_prepare_tags, mock_create_client):
+    """Test create trigger without user-provided tags."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.create_trigger.return_value = {'Name': 'test-trigger'}
+
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx,
+        operation='create-trigger',
+        trigger_name='test-trigger',
+        trigger_definition={
+            'Type': 'SCHEDULED',
+            'Actions': [{'JobName': 'test-job'}],
+        },
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.create_trigger.call_args
+    assert kwargs['Tags'] == {'ManagedBy': 'MCP'}
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+async def test_delete_trigger_client_error(mock_get_account_id, mock_get_region, mock_create_client):
+    """Test delete trigger with non-EntityNotFoundException ClientError."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_trigger.side_effect = ClientError(
+        {'Error': {'Code': 'AccessDeniedException', 'Message': 'Access denied'}}, 'get_trigger'
+    )
+
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx, operation='delete-trigger', trigger_name='test-trigger'
+    )
+    
+    assert result.isError
+    assert 'Error in manage_aws_glue_triggers' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_get_triggers_without_pagination(mock_create_client):
+    """Test get triggers without pagination parameters."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_triggers.return_value = {'Triggers': []}
+
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx, operation='get-triggers'
+    )
+
+    assert not result.isError
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+async def test_start_trigger_client_error(mock_get_account_id, mock_get_region, mock_create_client):
+    """Test start trigger with non-EntityNotFoundException ClientError."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_trigger.side_effect = ClientError(
+        {'Error': {'Code': 'AccessDeniedException', 'Message': 'Access denied'}}, 'get_trigger'
+    )
+
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx, operation='start-trigger', trigger_name='test-trigger'
+    )
+    
+    assert result.isError
+    assert 'Error in manage_aws_glue_triggers' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+async def test_stop_trigger_client_error(mock_get_account_id, mock_get_region, mock_create_client):
+    """Test stop trigger with non-EntityNotFoundException ClientError."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_trigger.side_effect = ClientError(
+        {'Error': {'Code': 'AccessDeniedException', 'Message': 'Access denied'}}, 'get_trigger'
+    )
+
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx, operation='stop-trigger', trigger_name='test-trigger'
+    )
+    
+    assert result.isError
+    assert 'Error in manage_aws_glue_triggers' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_triggers_no_write_access_fallback(mock_create_client):
+    """Test triggers no write access fallback response."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=False)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx, operation='unknown-operation', trigger_name='test-trigger'
+    )
+
+    assert result.isError
+    assert 'Operation unknown-operation is not allowed without write access' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_triggers_general_exception(mock_create_client):
+    """Test general exception handling in triggers."""
+    mock_glue_client = MagicMock()
+    mock_glue_client.get_trigger.side_effect = Exception('Test exception')
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx, operation='get-trigger', trigger_name='test-trigger'
+    )
+
+    assert result.isError
+    assert 'Error in manage_aws_glue_triggers: Test exception' in result.content[0].text
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_workflow_with_description_only(mock_prepare_tags, mock_create_client):
+    """Test creating workflow with description parameter only."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.create_workflow.return_value = {'Name': 'test-workflow'}
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='create-workflow',
+        workflow_name='test-workflow',
+        workflow_definition={'Description': 'Test workflow'},
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.create_workflow.call_args
+    assert kwargs['Description'] == 'Test workflow'
+    assert 'DefaultRunProperties' not in kwargs
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_workflow_with_default_run_properties_only(mock_prepare_tags, mock_create_client):
+    """Test creating workflow with DefaultRunProperties parameter only."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.create_workflow.return_value = {'Name': 'test-workflow'}
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='create-workflow',
+        workflow_name='test-workflow',
+        workflow_definition={'DefaultRunProperties': {'ENV': 'test'}},
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.create_workflow.call_args
+    assert kwargs['DefaultRunProperties'] == {'ENV': 'test'}
+    assert 'Description' not in kwargs
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.prepare_resource_tags')
+async def test_create_workflow_with_max_concurrent_runs_only(mock_prepare_tags, mock_create_client):
+    """Test creating workflow with MaxConcurrentRuns parameter only."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_prepare_tags.return_value = {'ManagedBy': 'MCP'}
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.create_workflow.return_value = {'Name': 'test-workflow'}
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='create-workflow',
+        workflow_name='test-workflow',
+        workflow_definition={'MaxConcurrentRuns': 2},
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.create_workflow.call_args
+    assert kwargs['MaxConcurrentRuns'] == 2
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+async def test_delete_workflow_entity_not_found(mock_get_account_id, mock_get_region, mock_create_client):
+    """Test delete workflow when workflow is not found."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_workflow.side_effect = ClientError(
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Workflow not found'}}, 'get_workflow'
+    )
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx, operation='delete-workflow', workflow_name='test-workflow'
+    )
+
+    assert result.isError
+    assert 'Workflow test-workflow not found' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_get_workflow_with_include_graph_true(mock_create_client):
+    """Test get workflow with include_graph parameter set to True."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_workflow.return_value = {'Workflow': {'Name': 'test-workflow'}}
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='get-workflow',
+        workflow_name='test-workflow',
+        workflow_definition={'include_graph': True},
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.get_workflow.call_args
+    assert kwargs['IncludeGraph'] == True
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_list_workflows_with_max_results(mock_create_client):
+    """Test list workflows with max_results parameter."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.list_workflows.return_value = {'Workflows': ['workflow1']}
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx, operation='list-workflows', max_results=10
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.list_workflows.call_args
+    assert kwargs['MaxResults'] == 10
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_list_workflows_with_next_token(mock_create_client):
+    """Test list workflows with next_token parameter."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.list_workflows.return_value = {'Workflows': ['workflow1']}
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx, operation='list-workflows', next_token='token123'
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.list_workflows.call_args
+    assert kwargs['NextToken'] == 'token123'
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+async def test_start_workflow_run_entity_not_found(mock_get_account_id, mock_get_region, mock_create_client):
+    """Test start workflow run when workflow is not found."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_workflow.side_effect = ClientError(
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Workflow not found'}}, 'get_workflow'
+    )
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx, operation='start-workflow-run', workflow_name='test-workflow'
+    )
+
+    assert result.isError
+    assert 'Workflow test-workflow not found' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.is_resource_mcp_managed')
+async def test_start_workflow_run_with_run_properties(
+    mock_is_mcp_managed, mock_get_account_id, mock_get_region, mock_create_client
+):
+    """Test start workflow run with run_properties."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_is_mcp_managed.return_value = True
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_workflow.return_value = {
+        'Workflow': {'Name': 'test-workflow', 'Tags': {'ManagedBy': 'MCP'}}
+    }
+    mock_glue_client.start_workflow_run.return_value = {'RunId': 'run-123'}
+
+    result = await handler.manage_aws_glue_workflows(
+        mock_ctx,
+        operation='start-workflow-run',
+        workflow_name='test-workflow',
+        workflow_definition={'run_properties': {'ENV': 'test'}},
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.start_workflow_run.call_args
+    assert kwargs['RunProperties'] == {'ENV': 'test'}
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+async def test_delete_trigger_entity_not_found(mock_get_account_id, mock_get_region, mock_create_client):
+    """Test delete trigger when trigger is not found."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_trigger.side_effect = ClientError(
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Trigger not found'}}, 'get_trigger'
+    )
+
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx, operation='delete-trigger', trigger_name='test-trigger'
+    )
+
+    assert result.isError
+    assert 'Trigger test-trigger not found' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_get_triggers_with_max_results(mock_create_client):
+    """Test get triggers with max_results parameter."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_triggers.return_value = {'Triggers': []}
+
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx, operation='get-triggers', max_results=10
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.get_triggers.call_args
+    assert kwargs['MaxResults'] == 10
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+async def test_get_triggers_with_next_token(mock_create_client):
+    """Test get triggers with next_token parameter."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_triggers.return_value = {'Triggers': []}
+
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx, operation='get-triggers', next_token='token123'
+    )
+
+    assert not result.isError
+    args, kwargs = mock_glue_client.get_triggers.call_args
+    assert kwargs['NextToken'] == 'token123'
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+async def test_start_trigger_entity_not_found(mock_get_account_id, mock_get_region, mock_create_client):
+    """Test start trigger when trigger is not found."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_trigger.side_effect = ClientError(
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Trigger not found'}}, 'get_trigger'
+    )
+
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx, operation='start-trigger', trigger_name='test-trigger'
+    )
+
+    assert result.isError
+    assert 'Trigger test-trigger not found' in result.content[0].text
+
+
+@pytest.mark.asyncio
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.create_boto3_client')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_region')
+@patch('awslabs.dataprocessing_mcp_server.utils.aws_helper.AwsHelper.get_aws_account_id')
+async def test_stop_trigger_entity_not_found(mock_get_account_id, mock_get_region, mock_create_client):
+    """Test stop trigger when trigger is not found."""
+    mock_glue_client = MagicMock()
+    mock_create_client.return_value = mock_glue_client
+    mock_get_region.return_value = 'us-east-1'
+    mock_get_account_id.return_value = '123456789012'
+    mock_mcp = MagicMock()
+    handler = GlueWorkflowAndTriggerHandler(mock_mcp, allow_write=True)
+    handler.glue_client = mock_glue_client
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_glue_client.get_trigger.side_effect = ClientError(
+        {'Error': {'Code': 'EntityNotFoundException', 'Message': 'Trigger not found'}}, 'get_trigger'
+    )
+
+    result = await handler.manage_aws_glue_triggers(
+        mock_ctx, operation='stop-trigger', trigger_name='test-trigger'
+    )
+
+    assert result.isError
+    assert 'Trigger test-trigger not found' in result.content[0].text


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Please provide a summary of what's being changed

Add unit tests for Glue Interactive Session and Glue Workflows MCP tools to bring the total coverage up to 93%

### User experience

> Please share what the user experience looks like before and after this change

No changes to user experience

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**: https://github.com/awslabs/mcp/issues/614

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
