### PR TITLE
feat: add comprehensive EMR EC2 cluster management handler

### DIFF
--- a/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/handlers/emr/emr_ec2_cluster_handler.py
+++ b/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/handlers/emr/emr_ec2_cluster_handler.py
@@ -1,0 +1,739 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""EMREc2ClusterHandler for Data Processing MCP Server."""
+import json
+import os
+import time
+from awslabs.dataprocessing_mcp_server.utils.aws_helper import AwsHelper
+from awslabs.dataprocessing_mcp_server.utils.logging_helper import (
+    LogLevel,
+    log_with_request_id,
+)
+from awslabs.dataprocessing_mcp_server.models.emr_models import (
+    CreateClusterResponse,
+    DescribeClusterResponse,
+    ModifyClusterResponse,
+    ModifyClusterAttributesResponse,
+    TerminateClustersResponse,
+    ListClustersResponse,
+    CreateSecurityConfigurationResponse,
+    DeleteSecurityConfigurationResponse,
+    DescribeSecurityConfigurationResponse,
+    ListSecurityConfigurationsResponse,
+)
+from awslabs.dataprocessing_mcp_server.utils.consts import MCP_MANAGED_TAG_KEY, MCP_MANAGED_TAG_VALUE
+from mcp.server.fastmcp import Context
+from mcp.types import TextContent, Content
+from pydantic import Field, BaseModel
+from typing import Dict, List, Optional, Tuple, Union, cast, Any
+from botocore.exceptions import ClientError, WaiterError
+
+
+class EMREc2ClusterHandler:
+    """Handler for Amazon EMR EC2 Cluster operations."""
+
+    def __init__(
+        self, mcp, allow_write: bool = False, allow_sensitive_data_access: bool = False
+    ):
+        """Initialize the EMR EC2 Cluster handler.
+
+        Args:
+            mcp: The MCP server instance
+            allow_write: Whether to enable write access (default: False)
+            allow_sensitive_data_access: Whether to allow access to sensitive data (default: False)
+        """
+        self.mcp = mcp
+        self.allow_write = allow_write
+        self.allow_sensitive_data_access = allow_sensitive_data_access
+        self.emr_client = AwsHelper.create_boto3_client("emr")
+
+        # Register tools
+        self.mcp.tool(name="manage_aws_emr_clusters")(self.manage_aws_emr_clusters)
+
+    def _create_error_response(self, operation: str, error_message: str):
+        """Create appropriate error response based on operation type."""
+        content: List[Content] = [TextContent(type="text", text=error_message)]
+        
+        if operation == "create-cluster":
+            return CreateClusterResponse(isError=True, content=content, cluster_id="", cluster_arn="", operation="create")
+        elif operation == "describe-cluster":
+            return DescribeClusterResponse(isError=True, content=content, cluster={})
+        elif operation == "modify-cluster":
+            return ModifyClusterResponse(isError=True, content=content, cluster_id="")
+        elif operation == "modify-cluster-attributes":
+            return ModifyClusterAttributesResponse(isError=True, content=content, cluster_id="")
+        elif operation == "terminate-clusters":
+            return TerminateClustersResponse(isError=True, content=content, cluster_ids=[])
+        elif operation == "list-clusters":
+            return ListClustersResponse(isError=True, content=content, clusters=[], count=0, marker="", operation="list")
+        elif operation == "create-security-configuration":
+            return CreateSecurityConfigurationResponse(isError=True, content=content, name="", creation_date_time="")
+        elif operation == "delete-security-configuration":
+            return DeleteSecurityConfigurationResponse(isError=True, content=content, name="")
+        elif operation == "describe-security-configuration":
+            return DescribeSecurityConfigurationResponse(isError=True, content=content, name="", security_configuration="", creation_date_time="")
+        elif operation == "list-security-configurations":
+            return ListSecurityConfigurationsResponse(isError=True, content=content, security_configurations=[], count=0, marker="", operation="list")
+        else:
+            return DescribeClusterResponse(isError=True, content=content, cluster={})
+
+    async def manage_aws_emr_clusters(
+        self,
+        ctx: Context,
+        operation: str = Field(
+            ...,
+            description="Operation to perform: create-cluster, describe-cluster, modify-cluster, modify-cluster-attributes, terminate-clusters, list-clusters, create-security-configuration, delete-security-configuration, describe-security-configuration, list-security-configurations. Choose read-only operations when write access is disabled.",
+        ),
+        cluster_id: Optional[str] = Field(
+            None,
+            description="ID of the EMR cluster (required for describe-cluster, modify-cluster, modify-cluster-attributes).",
+        ),
+        cluster_ids: Optional[List[str]] = Field(
+            None,
+            description="List of EMR cluster IDs (required for terminate-clusters).",
+        ),
+        name: Optional[str] = Field(
+            None,
+            description="Name of the EMR cluster (required for create-cluster). Cannot contain <, >, $, |, or ` (backtick).",
+        ),
+        log_uri: Optional[str] = Field(
+            None,
+            description="The path to the Amazon S3 location where logs for the cluster are stored (optional for create-cluster).",
+        ),
+        log_encryption_kms_key_id: Optional[str] = Field(
+            None,
+            description="The KMS key used for encrypting log files. Available with EMR 5.30.0 and later, excluding EMR 6.0.0 (optional for create-cluster).",
+        ),
+        release_label: Optional[str] = Field(
+            None,
+            description="The Amazon EMR release label, which determines the version of open-source application packages installed on the cluster (required for create-cluster). Format: emr-x.x.x",
+        ),
+        applications: Optional[List[Dict[str, str]]] = Field(
+            None,
+            description='The applications to be installed on the cluster (optional for create-cluster). Example: [{"Name": "Hadoop"}, {"Name": "Spark"}]',
+        ),
+        instances: Optional[Dict[str, Any]] = Field(
+            None,
+            description="A specification of the number and type of Amazon EC2 instances (required for create-cluster). Must include instance groups or instance fleets configuration.",
+        ),
+        steps: Optional[List[Dict[str, Any]]] = Field(
+            None,
+            description="A list of steps to run on the cluster (optional for create-cluster). Each step contains Name, ActionOnFailure, and HadoopJarStep properties.",
+        ),
+        bootstrap_actions: Optional[List[Dict[str, Any]]] = Field(
+            None,
+            description="A list of bootstrap actions to run on the cluster (optional for create-cluster). Each action contains Name, ScriptBootstrapAction properties.",
+        ),
+        configurations: Optional[List[Dict[str, Any]]] = Field(
+            None,
+            description="A list of configurations to apply to the cluster (optional for create-cluster). Applies only to EMR releases 4.x and later.",
+        ),
+        visible_to_all_users: Optional[bool] = Field(
+            None,
+            description="Whether the cluster is visible to all IAM users of the AWS account (optional for create-cluster, default: true).",
+        ),
+        service_role: Optional[str] = Field(
+            None,
+            description="The IAM role that Amazon EMR assumes to access AWS resources on your behalf (optional for create-cluster).",
+        ),
+        job_flow_role: Optional[str] = Field(
+            None,
+            description="The IAM role for EC2 instances running the job flow (required for create-cluster when using temporary credentials).",
+        ),
+        security_configuration: Optional[str] = Field(
+            None,
+            description="The name of a security configuration to apply to the cluster (optional for create-cluster).",
+        ),
+        auto_scaling_role: Optional[str] = Field(
+            None,
+            description="An IAM role for automatic scaling policies (optional for create-cluster). Default role is EMR_AutoScaling_DefaultRole.",
+        ),
+        scale_down_behavior: Optional[str] = Field(
+            None,
+            description="The way that individual Amazon EC2 instances terminate when an automatic scale-in activity occurs (optional for create-cluster). Values: TERMINATE_AT_INSTANCE_HOUR, TERMINATE_AT_TASK_COMPLETION.",
+        ),
+        custom_ami_id: Optional[str] = Field(
+            None,
+            description="A custom Amazon Linux AMI for the cluster (optional for create-cluster). Available only in EMR releases 5.7.0 and later.",
+        ),
+        ebs_root_volume_size: Optional[int] = Field(
+            None,
+            description="The size, in GiB, of the EBS root device volume of the Linux AMI (optional for create-cluster). Available in EMR releases 4.x and later.",
+        ),
+        ebs_root_volume_iops: Optional[int] = Field(
+            None,
+            description="The IOPS of the EBS root device volume of the Linux AMI (optional for create-cluster). Available in EMR releases 6.15.0 and later.",
+        ),
+        ebs_root_volume_throughput: Optional[int] = Field(
+            None,
+            description="The throughput, in MiB/s, of the EBS root device volume of the Linux AMI (optional for create-cluster). Available in EMR releases 6.15.0 and later.",
+        ),
+        repo_upgrade_on_boot: Optional[str] = Field(
+            None,
+            description="Applies only when CustomAmiID is used. Specifies the type of updates that are applied from the Amazon Linux AMI package repositories when an instance boots (optional for create-cluster).",
+        ),
+        kerberos_attributes: Optional[Dict[str, Any]] = Field(
+            None,
+            description="Attributes for Kerberos configuration when Kerberos authentication is enabled (optional for create-cluster).",
+        ),
+        step_concurrency_level: Optional[int] = Field(
+            None,
+            description="The number of steps that can be executed concurrently (required for modify-cluster). Range: 1-256.",
+        ),
+        auto_terminate: Optional[bool] = Field(
+            None,
+            description="Whether the cluster should auto-terminate after completing steps (optional for modify-cluster-attributes).",
+        ),
+        termination_protected: Optional[bool] = Field(
+            None,
+            description="Whether the cluster is protected from termination (optional for modify-cluster-attributes).",
+        ),
+        unhealthy_node_replacement: Optional[bool] = Field(
+            None,
+            description="Whether Amazon EMR should gracefully replace Amazon EC2 core instances that have degraded within the cluster (optional for create-cluster).",
+        ),
+        os_release_label: Optional[str] = Field(
+            None,
+            description="The Amazon Linux release for the cluster (optional for create-cluster).",
+        ),
+        placement_groups: Optional[List[Dict[str, Any]]] = Field(
+            None,
+            description="Placement group configuration for the cluster (optional for create-cluster).",
+        ),
+        cluster_states: Optional[List[str]] = Field(
+            None,
+            description="The cluster state filters to apply when listing clusters (optional for list-clusters).",
+        ),
+        created_after: Optional[str] = Field(
+            None,
+            description="The creation date and time beginning value filter for listing clusters (optional for list-clusters).",
+        ),
+        created_before: Optional[str] = Field(
+            None,
+            description="The creation date and time end value filter for listing clusters (optional for list-clusters).",
+        ),
+        marker: Optional[str] = Field(
+            None,
+            description="The pagination token for list-clusters operation.",
+        ),
+        security_configuration_name: Optional[str] = Field(
+            None,
+            description="Name of the security configuration (required for create-security-configuration, delete-security-configuration, describe-security-configuration).",
+        ),
+        security_configuration_json: Optional[Dict[str, Any]] = Field(
+            None,
+            description="JSON format security configuration (required for create-security-configuration).",
+        ),
+    ) -> Union[
+        CreateClusterResponse,
+        DescribeClusterResponse,
+        ModifyClusterResponse,
+        ModifyClusterAttributesResponse,
+        TerminateClustersResponse,
+        ListClustersResponse,
+        CreateSecurityConfigurationResponse,
+        DeleteSecurityConfigurationResponse,
+        DescribeSecurityConfigurationResponse,
+        ListSecurityConfigurationsResponse,
+    ]:
+        """Manage AWS EMR EC2 clusters with comprehensive control over cluster lifecycle.
+
+        This tool provides operations for managing Amazon EMR clusters running on EC2 instances,
+        including creating, configuring, monitoring, modifying, and terminating clusters. It also
+        supports security configuration management for EMR clusters.
+
+        ## Requirements
+        - The server must be run with the `--allow-write` flag for create-cluster, modify-cluster,
+          modify-cluster-attributes, terminate-clusters, create-security-configuration, and
+          delete-security-configuration operations
+        - Appropriate AWS permissions for EMR cluster operations
+
+        ## Operations
+        - **create-cluster**: Create a new EMR cluster with specified configurations
+        - **describe-cluster**: Get detailed information about a specific EMR cluster
+        - **modify-cluster**: Modify the step concurrency level of a running cluster
+        - **modify-cluster-attributes**: Modify auto-termination and termination protection settings
+        - **terminate-clusters**: Terminate one or more EMR clusters
+        - **list-clusters**: List all EMR clusters with optional filtering
+        - **create-security-configuration**: Create a new EMR security configuration
+        - **delete-security-configuration**: Delete an existing EMR security configuration
+        - **describe-security-configuration**: Get details about a specific security configuration
+        - **list-security-configurations**: List all available security configurations
+
+        ## Example
+        ```
+        # Create a basic EMR cluster with Spark
+        {
+          "operation": "create-cluster",
+          "name": "SparkCluster",
+          "release_label": "emr-7.9.0",
+          "applications": [{"Name": "Spark"}],
+          "instances": {
+            "InstanceGroups": [
+              {
+                "Name": "Master",
+                "InstanceRole": "MASTER",
+                "InstanceType": "m5.xlarge",
+                "InstanceCount": 1
+              },
+              {
+                "Name": "Core",
+                "InstanceRole": "CORE",
+                "InstanceType": "m5.xlarge",
+                "InstanceCount": 2
+              }
+            ],
+            "Ec2KeyName": "my-key-pair",
+            "KeepJobFlowAliveWhenNoSteps": true
+          }
+        }
+        ```
+
+        ## Usage Tips
+        - Use list-clusters to find cluster IDs before performing operations on specific clusters
+        - Check cluster state before performing operations that require specific states
+        - For large result sets, use pagination with marker parameter
+        - When creating clusters, consider using security configurations for encryption and authentication
+
+        Args:
+            ctx: MCP context
+            operation: Operation to perform
+            cluster_id: ID of the EMR cluster
+            cluster_ids: List of EMR cluster IDs
+            name: Name of the EMR cluster
+            log_uri: The path to the Amazon S3 location where logs for the cluster are stored
+            release_label: The Amazon EMR release label
+            applications: The applications to be installed on the cluster
+            instances: A specification of the number and type of Amazon EC2 instances
+            steps: A list of steps to run on the cluster
+            bootstrap_actions: A list of bootstrap actions to run on the cluster
+            configurations: A list of configurations to apply to the cluster
+            visible_to_all_users: Whether the cluster is visible to all IAM users of the AWS account
+            service_role: The IAM role that Amazon EMR assumes to access AWS resources on your behalf
+            job_flow_role: The IAM role for EC2 instances running the job flow (required for create-cluster when using temporary credentials). Also known as the EC2 instance profile.
+            security_configuration: The name of a security configuration to apply to the cluster
+            auto_scaling_role: An IAM role for automatic scaling policies
+            scale_down_behavior: The way that individual Amazon EC2 instances terminate when an automatic scale-in activity occurs
+            custom_ami_id: A custom Amazon Linux AMI for the cluster
+            ebs_root_volume_size: The size, in GiB, of the EBS root device volume of the Linux AMI
+            repo_upgrade_on_boot: Specifies the type of updates that are applied from the Amazon Linux AMI package repositories when an instance boots
+            kerberos_attributes: Attributes for Kerberos configuration when Kerberos authentication is enabled
+            step_concurrency_level: The number of steps that can be executed concurrently
+            auto_terminate: Whether the cluster should auto-terminate after completing steps
+            termination_protected: Whether the cluster is protected from termination
+            cluster_states: The cluster state filters to apply when listing clusters
+            created_after: The creation date and time beginning value filter for listing clusters
+            created_before: The creation date and time end value filter for listing clusters
+            marker: The pagination token for list-clusters operation
+            security_configuration_name: Name of the security configuration
+            security_configuration_json: JSON format security configuration
+
+        Returns:
+            Union of response types specific to the operation performed
+        """
+        try:
+            log_with_request_id(
+                ctx,
+                LogLevel.INFO,
+                f"EMR EC2 Cluster Handler - Tool: manage_aws_emr_ec2_clusters - Operation: {operation}",
+            )
+
+            if not self.allow_write and operation in [
+                "create-cluster",
+                "modify-cluster",
+                "modify-cluster-attributes",
+                "terminate-clusters",
+                "create-security-configuration",
+                "delete-security-configuration",
+            ]:
+                error_message = (
+                    f"Operation {operation} is not allowed without write access"
+                )
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                return self._create_error_response(operation, error_message)
+
+            if operation == "create-cluster":
+                # Check required parameters manually before proceeding
+                missing_params = []
+                if name is None:
+                    missing_params.append("name")
+                if release_label is None:
+                    missing_params.append("release_label")
+                if instances is None:
+                    missing_params.append("instances")
+                
+                if missing_params:
+                    error_message = "name, release_label, and instances are required for create-cluster operation"
+                    return self._create_error_response(operation, error_message)
+
+                # Prepare parameters
+                params = {
+                    "Name": name,
+                    "ReleaseLabel": release_label,
+                    "Instances": instances,
+                }
+
+                if log_uri is not None:
+                    params["LogUri"] = log_uri
+
+                if log_encryption_kms_key_id is not None:
+                    params["LogEncryptionKmsKeyId"] = log_encryption_kms_key_id
+
+                if applications is not None:
+                    params["Applications"] = applications
+
+                if steps is not None:
+                    params["Steps"] = steps
+
+                if bootstrap_actions is not None:
+                    params["BootstrapActions"] = bootstrap_actions
+
+                if configurations is not None:
+                    params["Configurations"] = configurations
+
+                if visible_to_all_users is not None:
+                    params["VisibleToAllUsers"] = visible_to_all_users
+
+                if service_role is not None:
+                    params["ServiceRole"] = service_role
+
+                if job_flow_role is not None:
+                    params["JobFlowRole"] = job_flow_role
+
+                if security_configuration is not None:
+                    params["SecurityConfiguration"] = security_configuration
+
+                if auto_scaling_role is not None:
+                    params["AutoScalingRole"] = auto_scaling_role
+
+                if scale_down_behavior is not None:
+                    params["ScaleDownBehavior"] = scale_down_behavior
+
+                if custom_ami_id is not None:
+                    params["CustomAmiId"] = custom_ami_id
+
+                if ebs_root_volume_size is not None:
+                    params["EbsRootVolumeSize"] = ebs_root_volume_size
+
+                if ebs_root_volume_iops is not None:
+                    params["EbsRootVolumeIops"] = ebs_root_volume_iops
+
+                if ebs_root_volume_throughput is not None:
+                    params["EbsRootVolumeThroughput"] = ebs_root_volume_throughput
+
+                if repo_upgrade_on_boot is not None:
+                    params["RepoUpgradeOnBoot"] = repo_upgrade_on_boot
+
+                if kerberos_attributes is not None:
+                    params["KerberosAttributes"] = kerberos_attributes
+
+                if unhealthy_node_replacement is not None:
+                    params["UnhealthyNodeReplacement"] = unhealthy_node_replacement
+
+                if os_release_label is not None:
+                    params["OSReleaseLabel"] = os_release_label
+
+                if placement_groups is not None:
+                    params["PlacementGroups"] = placement_groups
+
+                # Add MCP management tags
+                resource_tags = AwsHelper.prepare_resource_tags("EMRCluster")
+                aws_tags = [{'Key': key, 'Value': value} for key, value in resource_tags.items()]
+                params["Tags"] = aws_tags
+
+                # Create cluster
+                response = self.emr_client.run_job_flow(**params)
+
+                content: List[Content] = [
+                    TextContent(
+                        type="text",
+                        text=f"Successfully created EMR cluster {name} with MCP management tags",
+                    )
+                ]
+                return CreateClusterResponse(
+                    isError=False,
+                    content=content,
+                    cluster_id=response.get("JobFlowId", ""),
+                    cluster_arn=None,  # EMR doesn't return ARN in the create response
+                )
+
+            elif operation == "describe-cluster":
+                if cluster_id is None:
+                    error_message = "cluster_id is required for describe-cluster operation"
+                    return self._create_error_response(operation, error_message)
+
+                # Describe cluster
+                response = self.emr_client.describe_cluster(ClusterId=cluster_id)
+
+                content: List[Content] = [
+                    TextContent(
+                        type="text",
+                        text=f"Successfully described EMR cluster {cluster_id}",
+                    )
+                ]
+                return DescribeClusterResponse(
+                    isError=False,
+                    content=content,
+                    cluster=response.get("Cluster", {}),
+                )
+
+            elif operation == "modify-cluster":
+                if cluster_id is None:
+                    error_message = "cluster_id is required for modify-cluster operation"
+                    return self._create_error_response(operation, error_message)
+                if step_concurrency_level is None:
+                    error_message = "step_concurrency_level is required for modify-cluster operation"
+                    return self._create_error_response(operation, error_message)
+
+                # Modify cluster
+                response = self.emr_client.modify_cluster(
+                    ClusterId=cluster_id,
+                    StepConcurrencyLevel=step_concurrency_level,
+                )
+
+                content: List[Content] = [
+                    TextContent(
+                        type="text",
+                        text=f"Successfully modified EMR cluster {cluster_id}",
+                    )
+                ]
+                return ModifyClusterResponse(
+                    isError=False,
+                    content=content,
+                    cluster_id=cluster_id,
+                    step_concurrency_level=response.get("StepConcurrencyLevel"),
+                )
+
+            elif operation == "modify-cluster-attributes":
+                if cluster_id is None:
+                    error_message = "cluster_id is required for modify-cluster-attributes operation"
+                    return self._create_error_response(operation, error_message)
+
+                if auto_terminate is None and termination_protected is None:
+                    error_message = "At least one of auto_terminate or termination_protected must be provided for modify-cluster-attributes operation"
+                    return self._create_error_response(operation, error_message)
+
+                # Modify cluster attributes
+                if auto_terminate is not None:
+                    self.emr_client.set_termination_protection(
+                        JobFlowIds=[cluster_id],
+                        TerminationProtected=not auto_terminate,
+                    )
+
+                if termination_protected is not None:
+                    self.emr_client.set_termination_protection(
+                        JobFlowIds=[cluster_id],
+                        TerminationProtected=termination_protected,
+                    )
+
+                content: List[Content] = [
+                    TextContent(
+                        type="text",
+                        text=f"Successfully modified attributes for EMR cluster {cluster_id}",
+                    )
+                ]
+                return ModifyClusterAttributesResponse(
+                    isError=False,
+                    content=content,
+                    cluster_id=cluster_id,
+                )
+
+            elif operation == "terminate-clusters":
+                if cluster_ids is None:
+                    error_message = "cluster_ids is required for terminate-clusters operation"
+                    return self._create_error_response(operation, error_message)
+
+                # Verify that all clusters are managed by MCP before terminating
+                unmanaged_clusters = []
+                for cluster_id in cluster_ids:
+                    try:
+                        response = self.emr_client.describe_cluster(ClusterId=cluster_id)
+                        tags_list = response.get('Cluster', {}).get('Tags', [])
+                        cluster_tags = {tag['Key']: tag['Value'] for tag in tags_list}
+                        # Check if cluster is managed by MCP
+                        if cluster_tags.get(MCP_MANAGED_TAG_KEY) != MCP_MANAGED_TAG_VALUE:
+                            unmanaged_clusters.append(cluster_id)
+                    except Exception:
+                        unmanaged_clusters.append(cluster_id)
+
+                if unmanaged_clusters:
+                    error_message = f"Cannot terminate clusters {unmanaged_clusters} - they are not managed by the MCP server (missing required tags)"
+                    log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                    return self._create_error_response(operation, error_message)
+
+                # Terminate clusters
+                self.emr_client.terminate_job_flows(JobFlowIds=cluster_ids)
+
+                content: List[Content] = [
+                    TextContent(
+                        type="text",
+                        text=f"Successfully initiated termination for {len(cluster_ids)} MCP-managed EMR clusters",
+                    )
+                ]
+                return TerminateClustersResponse(
+                    isError=False,
+                    content=content,
+                    cluster_ids=cluster_ids,
+                )
+
+            elif operation == "list-clusters":
+                # Prepare parameters - only include non-None values
+                params = {}
+                if cluster_states is not None:
+                    params["ClusterStates"] = cluster_states
+                if created_after is not None:
+                    params["CreatedAfter"] = created_after
+                if created_before is not None:
+                    params["CreatedBefore"] = created_before
+                if marker is not None:
+                    params["Marker"] = marker
+
+                # List clusters
+                response = self.emr_client.list_clusters(**params)
+
+                clusters = response.get("Clusters", [])
+                content: List[Content] = [
+                    TextContent(
+                        type="text", text="Successfully listed EMR clusters"
+                    )
+                ]
+                return ListClustersResponse(
+                    isError=False,
+                    content=content,
+                    clusters=clusters,
+                    count=len(clusters),
+                    marker=response.get("Marker"),
+                    operation="list",
+                )
+
+            elif operation == "create-security-configuration":
+                if (
+                    security_configuration_name is None
+                    or security_configuration_json is None
+                ):
+                    error_message = "security_configuration_name and security_configuration_json are required for create-security-configuration operation"
+                    return self._create_error_response(operation, error_message)
+
+                security_configuration_json_str = json.dumps(security_configuration_json)
+                response = self.emr_client.create_security_configuration(
+                    Name=security_configuration_name,
+                    SecurityConfiguration=security_configuration_json_str,
+                )
+
+                creation_date_time = response.get("CreationDateTime", "")
+                if hasattr(creation_date_time, "isoformat"):
+                    creation_date_time = creation_date_time.isoformat()
+
+                content: List[Content] = [
+                    TextContent(
+                        type="text",
+                        text=f"Successfully created EMR security configuration {security_configuration_name}",
+                    )
+                ]
+                return CreateSecurityConfigurationResponse(
+                    isError=False,
+                    content=content,
+                    name=security_configuration_name,
+                    creation_date_time=creation_date_time,
+                )
+
+            elif operation == "delete-security-configuration":
+                if security_configuration_name is None:
+                    error_message = "security_configuration_name is required for delete-security-configuration operation"
+                    return self._create_error_response(operation, error_message)
+
+                # Delete security configuration
+                self.emr_client.delete_security_configuration(
+                    Name=security_configuration_name
+                )
+
+                content: List[Content] = [
+                    TextContent(
+                        type="text",
+                        text=f"Successfully deleted EMR security configuration {security_configuration_name}",
+                    )
+                ]
+                return DeleteSecurityConfigurationResponse(
+                    isError=False,
+                    content=content,
+                    name=security_configuration_name,
+                )
+
+            elif operation == "describe-security-configuration":
+                if security_configuration_name is None:
+                    error_message = "security_configuration_name is required for describe-security-configuration operation"
+                    return self._create_error_response(operation, error_message)
+
+                # Describe security configuration
+                response = self.emr_client.describe_security_configuration(
+                    Name=security_configuration_name
+                )
+
+                creation_date_time = response.get("CreationDateTime", "")
+                if hasattr(creation_date_time, "isoformat"):
+                    creation_date_time = creation_date_time.isoformat()
+
+                content: List[Content] = [
+                    TextContent(
+                        type="text",
+                        text=f"Successfully described EMR security configuration {security_configuration_name}",
+                    )
+                ]
+                return DescribeSecurityConfigurationResponse(
+                    isError=False,
+                    content=content,
+                    name=security_configuration_name,
+                    security_configuration=response.get("SecurityConfiguration", ""),
+                    creation_date_time=creation_date_time,
+                )
+
+            elif operation == "list-security-configurations":
+                # Prepare parameters
+                params = {}
+                if marker is not None:
+                    params["Marker"] = marker
+
+                # List security configurations
+                response = self.emr_client.list_security_configurations(**params)
+
+                security_configurations = response.get("SecurityConfigurations", [])
+                content: List[Content] = [
+                    TextContent(
+                        type="text",
+                        text="Successfully listed EMR security configurations",
+                    )
+                ]
+                return ListSecurityConfigurationsResponse(
+                    isError=False,
+                    content=content,
+                    security_configurations=security_configurations,
+                    count=len(security_configurations),
+                    marker=response.get("Marker"),
+                    operation="list",
+                )
+
+            else:
+                error_message = f"Invalid operation: {operation}. Must be one of: create-cluster, describe-cluster, modify-cluster, modify-cluster-attributes, terminate-clusters, list-clusters, create-security-configuration, delete-security-configuration, describe-security-configuration, list-security-configurations"
+                log_with_request_id(ctx, LogLevel.ERROR, error_message)
+                return self._create_error_response("describe-cluster", error_message)
+
+        except ValueError as e:
+            error_message = str(e)
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+            return self._create_error_response(operation, error_message)
+        except Exception as e:
+            error_message = f"Error in manage_aws_emr_clusters: {str(e)}"
+            log_with_request_id(ctx, LogLevel.ERROR, error_message)
+            return self._create_error_response(operation, error_message)

--- a/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/models/emr_models.py
+++ b/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/models/emr_models.py
@@ -15,7 +15,7 @@
 
 """Response models for EMR operations."""
 
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, Content, TextContent
 from pydantic import BaseModel, Field
 from typing import Any, Dict, List, Optional
 
@@ -142,6 +142,7 @@ class ListInstanceFleetsResponseModel(EMRResponseBase):
     instance_fleets: List[Dict[str, Any]] = Field(..., description='List of instance fleets')
     count: int = Field(..., description='Number of instance fleets found')
     marker: Optional[str] = Field(None, description='Token for pagination')
+    operation: str = Field(default='list', description='Operation performed')
 
 
 class ListInstanceFleetsResponse(CallToolResult):
@@ -160,6 +161,7 @@ class ListInstanceFleetsResponse(CallToolResult):
             instance_fleets=model.instance_fleets,
             count=model.count,
             marker=model.marker,
+            operation=model.operation,
         )
 
 
@@ -169,6 +171,7 @@ class ListInstancesResponseModel(EMRResponseBase):
     instances: List[Dict[str, Any]] = Field(..., description='List of instances')
     count: int = Field(..., description='Number of instances found')
     marker: Optional[str] = Field(None, description='Token for pagination')
+    operation: str = Field(default='list', description='Operation performed')
 
 
 class ListInstancesResponse(CallToolResult):
@@ -187,6 +190,7 @@ class ListInstancesResponse(CallToolResult):
             instances=model.instances,
             count=model.count,
             marker=model.marker,
+            operation=model.operation,
         )
 
 
@@ -199,6 +203,7 @@ class ListSupportedInstanceTypesResponseModel(BaseModel):
     count: int = Field(..., description='Number of instance types found')
     marker: Optional[str] = Field(None, description='Token for pagination')
     release_label: str = Field(..., description='EMR release label')
+    operation: str = Field(default='list', description='Operation performed')
 
 
 class ListSupportedInstanceTypesResponse(CallToolResult):
@@ -220,6 +225,7 @@ class ListSupportedInstanceTypesResponse(CallToolResult):
             count=model.count,
             marker=model.marker,
             release_label=model.release_label,
+            operation=model.operation,
         )
 
 
@@ -342,3 +348,120 @@ class ListStepsResponse(CallToolResult):
             marker=model.marker,
             operation=model.operation,
         )
+
+
+# Response models for EMR Security Configuration Operations
+
+
+class CreateSecurityConfigurationResponse(CallToolResult):
+    """Response model for create security configuration operation."""
+
+    isError: bool = Field(default=False, description='Whether the operation resulted in an error')
+    content: List[Content] = Field(..., description='Content of the response')
+    name: str = Field(..., description='Name of the created security configuration')
+    creation_date_time: str = Field(..., description='Creation timestamp in ISO format')
+    operation: str = Field(default='create', description='Operation performed')
+
+
+class DeleteSecurityConfigurationResponse(CallToolResult):
+    """Response model for delete security configuration operation."""
+
+    isError: bool = Field(default=False, description='Whether the operation resulted in an error')
+    content: List[Content] = Field(..., description='Content of the response')
+    name: str = Field(..., description='Name of the deleted security configuration')
+    operation: str = Field(default='delete', description='Operation performed')
+
+
+class DescribeSecurityConfigurationResponse(CallToolResult):
+    """Response model for describe security configuration operation."""
+
+    isError: bool = Field(default=False, description='Whether the operation resulted in an error')
+    content: List[Content] = Field(..., description='Content of the response')
+    name: str = Field(..., description='Name of the security configuration')
+    security_configuration: str = Field(..., description='Security configuration content')
+    creation_date_time: str = Field(..., description='Creation timestamp in ISO format')
+    operation: str = Field(default='describe', description='Operation performed')
+
+
+class ListSecurityConfigurationsResponse(CallToolResult):
+    """Response model for list security configurations operation."""
+
+    isError: bool = Field(default=False, description='Whether the operation resulted in an error')
+    content: List[Content] = Field(..., description='Content of the response')
+    security_configurations: List[Dict[str, Any]] = Field(
+        ..., description='List of security configurations'
+    )
+    count: int = Field(..., description='Number of security configurations found')
+    marker: Optional[str] = Field(None, description='Token for pagination')
+    operation: str = Field(default='list', description='Operation performed')
+
+
+# Response models for EMR Cluster Operations
+
+
+class CreateClusterResponse(CallToolResult):
+    """Response model for create cluster operation."""
+
+    isError: bool = Field(default=False, description='Whether the operation resulted in an error')
+    content: List[Content] = Field(..., description='Content of the response')
+    cluster_id: Optional[str] = Field(default='', description='ID of the created cluster')
+    cluster_arn: Optional[str] = Field(default='', description='ARN of the created cluster')
+    operation: str = Field(default='create', description='Operation performed')
+
+
+class DescribeClusterResponse(CallToolResult):
+    """Response model for describe cluster operation."""
+
+    isError: bool = Field(default=False, description='Whether the operation resulted in an error')
+    content: List[Content] = Field(..., description='Content of the response')
+    cluster: Dict[str, Any] = Field(..., description='Cluster details')
+    operation: str = Field(default='describe', description='Operation performed')
+
+
+class ModifyClusterResponse(CallToolResult):
+    """Response model for modify cluster operation."""
+
+    isError: bool = Field(default=False, description='Whether the operation resulted in an error')
+    content: List[Content] = Field(..., description='Content of the response')
+    cluster_id: str = Field(..., description='ID of the modified cluster')
+    step_concurrency_level: Optional[int] = Field(None, description='Step concurrency level')
+    operation: str = Field(default='modify', description='Operation performed')
+
+
+class ModifyClusterAttributesResponse(CallToolResult):
+    """Response model for modify cluster attributes operation."""
+
+    isError: bool = Field(default=False, description='Whether the operation resulted in an error')
+    content: List[Content] = Field(..., description='Content of the response')
+    cluster_id: str = Field(..., description='ID of the cluster with modified attributes')
+    operation: str = Field(default='modify_attributes', description='Operation performed')
+
+
+class TerminateClustersResponse(CallToolResult):
+    """Response model for terminate clusters operation."""
+
+    isError: bool = Field(default=False, description='Whether the operation resulted in an error')
+    content: List[Content] = Field(..., description='Content of the response')
+    cluster_ids: List[str] = Field(..., description='IDs of the terminated clusters')
+    operation: str = Field(default='terminate', description='Operation performed')
+
+
+class ListClustersResponse(CallToolResult):
+    """Response model for list clusters operation."""
+
+    isError: bool = Field(default=False, description='Whether the operation resulted in an error')
+    content: List[Content] = Field(..., description='Content of the response')
+    clusters: List[Dict[str, Any]] = Field(..., description='List of clusters')
+    count: int = Field(..., description='Number of clusters found')
+    marker: Optional[str] = Field(None, description='Token for pagination')
+    operation: str = Field(default='list', description='Operation performed')
+
+
+class WaitClusterResponse(CallToolResult):
+    """Response model for wait operation."""
+
+    isError: bool = Field(default=False, description='Whether the operation resulted in an error')
+    content: List[Content] = Field(..., description='Content of the response')
+    cluster_id: str = Field(..., description='ID of the cluster')
+    state: str = Field(..., description='Current state of the cluster')
+    operation: str = Field(default='wait', description='Operation performed')

--- a/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/server.py
+++ b/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/server.py
@@ -27,6 +27,9 @@ import argparse
 from awslabs.dataprocessing_mcp_server.handlers.athena.athena_query_handler import (
     AthenaQueryHandler,
 )
+from awslabs.dataprocessing_mcp_server.handlers.emr.emr_ec2_cluster_handler import (
+    EMREc2ClusterHandler,
+)
 from awslabs.dataprocessing_mcp_server.handlers.emr.emr_ec2_instance_handler import (
     EMREc2InstanceHandler,
 )
@@ -238,6 +241,11 @@ def main():
         allow_sensitive_data_access=allow_sensitive_data_access,
     )
     GlueCommonsHandler(
+        mcp,
+        allow_write=allow_write,
+        allow_sensitive_data_access=allow_sensitive_data_access,
+    )
+    EMREc2ClusterHandler(
         mcp,
         allow_write=allow_write,
         allow_sensitive_data_access=allow_sensitive_data_access,

--- a/src/dataprocessing-mcp-server/tests/handlers/emr/test_emr_ec2_cluster_handler.py
+++ b/src/dataprocessing-mcp-server/tests/handlers/emr/test_emr_ec2_cluster_handler.py
@@ -1,0 +1,879 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for EMREc2ClusterHandler."""
+
+import pytest
+from awslabs.dataprocessing_mcp_server.handlers.emr.emr_ec2_cluster_handler import EMREc2ClusterHandler
+from awslabs.dataprocessing_mcp_server.models.emr_models import CreateClusterResponse, DescribeClusterResponse
+from mcp.server.fastmcp import Context
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture
+def mock_aws_helper():
+    """Create a mock AwsHelper instance for testing."""
+    with patch('awslabs.dataprocessing_mcp_server.handlers.emr.emr_ec2_cluster_handler.AwsHelper') as mock:
+        mock.create_boto3_client.return_value = MagicMock()
+        mock.prepare_resource_tags.return_value = {'MCP:Managed': 'true', 'MCP:ResourceType': 'EMRCluster'}
+        yield mock
+
+
+@pytest.fixture
+def handler(mock_aws_helper):
+    """Create a mock EMREc2ClusterHandler instance for testing."""
+    mcp = MagicMock()
+    mcp.tool = MagicMock(return_value=lambda f: f)
+    return EMREc2ClusterHandler(mcp, allow_write=True, allow_sensitive_data_access=True)
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock context instance for testing."""
+    return MagicMock(spec=Context)
+
+
+@pytest.mark.asyncio
+async def test_create_cluster_success(handler, mock_context):
+    """Test successful creation of an EMR cluster."""
+    handler.emr_client = MagicMock()
+    handler.emr_client.run_job_flow.return_value = {
+        "JobFlowId": "j-1234567890ABCDEF0",
+        "ClusterArn": "arn:aws:elasticmapreduce:us-west-2:123456789012:cluster/j-1234567890ABCDEF0"
+    }
+
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="create-cluster",
+        name="TestCluster",
+        release_label="emr-7.9.0",
+        instances={
+            "InstanceGroups": [
+                {
+                    "Name": "Master",
+                    "InstanceRole": "MASTER",
+                    "InstanceType": "m5.xlarge",
+                    "InstanceCount": 1
+                },
+                {
+                    "Name": "Core",
+                    "InstanceRole": "CORE",
+                    "InstanceType": "m5.xlarge",
+                    "InstanceCount": 2
+                }
+            ],
+            "Ec2KeyName": "my-key-pair",
+            "KeepJobFlowAliveWhenNoSteps": True
+        },
+        service_role="EMR_EC2_DefaultRole",
+        job_flow_role="EMR_EC2_DefaultRole"
+    )
+
+    assert not response.isError
+    assert response.cluster_id == "j-1234567890ABCDEF0"
+    handler.emr_client.run_job_flow.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_cluster_missing_name(handler, mock_context):
+    """Test that creating a cluster fails when name is missing."""
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        name=None,
+        operation="create-cluster",
+        release_label="emr-7.9.0",
+        instances={
+            "InstanceGroups": [
+                {
+                    "Name": "Master",
+                    "InstanceRole": "MASTER",
+                    "InstanceType": "m5.xlarge",
+                    "InstanceCount": 1
+                }
+            ]
+        }
+    )
+    
+    assert response.isError is True
+    assert "name, release_label, and instances are required for create-cluster operation" in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_create_cluster_missing_release_label(handler, mock_context):
+    """Test that creating a cluster fails when release_label is missing."""
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        release_label=None,
+        operation="create-cluster",
+        name="TestCluster",
+        instances={
+            "InstanceGroups": [
+                {
+                    "Name": "Master",
+                    "InstanceRole": "MASTER",
+                    "InstanceType": "m5.xlarge",
+                    "InstanceCount": 1
+                }
+            ]
+        }
+    )
+    
+    assert response.isError is True
+    assert "name, release_label, and instances are required for create-cluster operation" in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_create_cluster_missing_instances(handler, mock_context):
+    """Test that creating a cluster fails when instances is missing."""
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        instances=None,
+        operation="create-cluster",
+        name="TestCluster",
+        release_label="emr-7.9.0"
+    )
+    
+    assert response.isError is True
+    assert "name, release_label, and instances are required for create-cluster operation" in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_create_cluster_error(handler, mock_context):
+    """Test error handling during cluster creation."""
+    handler.emr_client = MagicMock()
+    handler.emr_client.run_job_flow.side_effect = Exception("Test exception")
+
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="create-cluster",
+        name="TestCluster",
+        release_label="emr-7.9.0",
+        instances={
+            "InstanceGroups": [
+                {
+                    "Name": "Master",
+                    "InstanceRole": "MASTER",
+                    "InstanceType": "m5.xlarge",
+                    "InstanceCount": 1
+                }
+            ]
+        }
+    )
+
+    assert response.isError
+    assert "Error in manage_aws_emr_clusters: Test exception" in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_describe_cluster_success(handler, mock_context):
+    """Test successful description of an EMR cluster."""
+    handler.emr_client = MagicMock()
+    handler.emr_client.describe_cluster.return_value = {
+        "Cluster": {
+            "Id": "j-1234567890ABCDEF0",
+            "Name": "TestCluster",
+            "Status": {"State": "RUNNING"}
+        }
+    }
+
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="describe-cluster",
+        cluster_id="j-1234567890ABCDEF0"
+    )
+
+    assert not response.isError
+    assert response.cluster["Id"] == "j-1234567890ABCDEF0"
+    assert response.cluster["Name"] == "TestCluster"
+    handler.emr_client.describe_cluster.assert_called_once_with(ClusterId="j-1234567890ABCDEF0")
+
+
+@pytest.mark.asyncio
+async def test_describe_cluster_missing_id(handler, mock_context):
+    """Test that describing a cluster fails when cluster_id is missing."""
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        cluster_id=None,
+        operation="describe-cluster"
+    )
+    
+    assert response.isError is True
+    assert "cluster_id is required for describe-cluster operation" in response.content[0].text
+
+
+# Write access restriction tests
+@pytest.mark.asyncio
+async def test_create_cluster_no_write_access(mock_aws_helper, mock_context):
+    """Test that creating a cluster fails without write access."""
+    mcp = MagicMock()
+    mcp.tool = MagicMock(return_value=lambda f: f)
+    handler = EMREc2ClusterHandler(mcp, allow_write=False)
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="create-cluster",
+        name="TestCluster",
+        release_label="emr-7.9.0",
+        instances={"InstanceGroups": []}
+    )
+    
+    assert response.isError
+    assert "Operation create-cluster is not allowed without write access" in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_terminate_clusters_no_write_access(mock_aws_helper, mock_context):
+    """Test that terminating clusters fails without write access."""
+    mcp = MagicMock()
+    mcp.tool = MagicMock(return_value=lambda f: f)
+    handler = EMREc2ClusterHandler(mcp, allow_write=False)
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="terminate-clusters",
+        cluster_ids=["j-1234567890ABCDEF0"]
+    )
+    
+    assert response.isError
+    assert "Operation terminate-clusters is not allowed without write access" in response.content[0].text
+
+
+# AWS permission and client error tests
+@pytest.mark.asyncio
+async def test_describe_cluster_aws_error(handler, mock_context):
+    """Test AWS client error handling for describe cluster."""
+    from botocore.exceptions import ClientError
+    
+    handler.emr_client = MagicMock()
+    handler.emr_client.describe_cluster.side_effect = ClientError(
+        {"Error": {"Code": "ClusterNotFound", "Message": "Cluster not found"}},
+        "DescribeCluster"
+    )
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="describe-cluster",
+        cluster_id="j-nonexistent"
+    )
+    
+    assert response.isError
+    assert "Error in manage_aws_emr_clusters:" in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_create_cluster_access_denied(handler, mock_context):
+    """Test AWS access denied error during cluster creation."""
+    from botocore.exceptions import ClientError
+    
+    handler.emr_client = MagicMock()
+    handler.emr_client.run_job_flow.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "Access denied"}},
+        "RunJobFlow"
+    )
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="create-cluster",
+        name="TestCluster",
+        release_label="emr-7.9.0",
+        instances={"InstanceGroups": []}
+    )
+    
+    assert response.isError
+    assert "Error in manage_aws_emr_clusters:" in response.content[0].text
+
+
+# List clusters tests
+@pytest.mark.asyncio
+async def test_list_clusters_success(handler, mock_context):
+    """Test successful listing of EMR clusters."""
+    from awslabs.dataprocessing_mcp_server.models.emr_models import ListClustersResponse
+    
+    handler.emr_client = MagicMock()
+    handler.emr_client.list_clusters.return_value = {
+        "Clusters": [
+            {"Id": "j-1234567890ABCDEF0", "Name": "Cluster1", "Status": {"State": "RUNNING"}},
+            {"Id": "j-0987654321FEDCBA0", "Name": "Cluster2", "Status": {"State": "TERMINATED"}}
+        ],
+        "Marker": "next-page-token"
+    }
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="list-clusters",
+        cluster_states=["RUNNING", "TERMINATED"]
+    )
+    
+    assert isinstance(response, ListClustersResponse)
+    assert not response.isError
+    assert response.count == 2
+    assert response.marker == "next-page-token"
+    # Verify the call was made and check the important parameter
+    handler.emr_client.list_clusters.assert_called_once()
+    call_args = handler.emr_client.list_clusters.call_args[1]
+    assert call_args["ClusterStates"] == ["RUNNING", "TERMINATED"]
+
+
+# Terminate clusters tests
+@pytest.mark.asyncio
+async def test_terminate_clusters_success(handler, mock_context):
+    """Test successful termination of MCP-managed clusters."""
+    from awslabs.dataprocessing_mcp_server.models.emr_models import TerminateClustersResponse
+    
+    handler.emr_client = MagicMock()
+    handler.emr_client.describe_cluster.return_value = {
+        "Cluster": {
+            "Tags": [
+                {"Key": "ManagedBy", "Value": "DataprocessingMcpServer"},
+                {"Key": "ResourceType", "Value": "EMRCluster"}
+            ]
+        }
+    }
+    handler.emr_client.terminate_job_flows.return_value = {}
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="terminate-clusters",
+        cluster_ids=["j-1234567890ABCDEF0"]
+    )
+    
+    assert isinstance(response, TerminateClustersResponse)
+    assert not response.isError
+    assert response.cluster_ids == ["j-1234567890ABCDEF0"]
+    handler.emr_client.terminate_job_flows.assert_called_once_with(JobFlowIds=["j-1234567890ABCDEF0"])
+
+
+@pytest.mark.asyncio
+async def test_terminate_clusters_unmanaged(handler, mock_context):
+    """Test that terminating unmanaged clusters fails."""
+    handler.emr_client = MagicMock()
+    handler.emr_client.describe_cluster.return_value = {
+        "Cluster": {"Tags": [{"Key": "Other", "Value": "tag"}]}
+    }
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="terminate-clusters",
+        cluster_ids=["j-1234567890ABCDEF0"]
+    )
+    
+    assert response.isError
+    assert "Cannot terminate clusters" in response.content[0].text
+    assert "not managed by the MCP server" in response.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_terminate_clusters_missing_ids(handler, mock_context):
+    """Test that terminating clusters fails when cluster_ids is missing."""
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="terminate-clusters",
+        cluster_ids=None
+    )
+    
+    assert response.isError
+    assert "cluster_ids is required for terminate-clusters operation" in response.content[0].text
+
+
+# Modify cluster tests
+@pytest.mark.asyncio
+async def test_modify_cluster_success(handler, mock_context):
+    """Test successful modification of cluster step concurrency."""
+    from awslabs.dataprocessing_mcp_server.models.emr_models import ModifyClusterResponse
+    
+    handler.emr_client = MagicMock()
+    handler.emr_client.modify_cluster.return_value = {"StepConcurrencyLevel": 5}
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="modify-cluster",
+        cluster_id="j-1234567890ABCDEF0",
+        step_concurrency_level=5
+    )
+    
+    assert isinstance(response, ModifyClusterResponse)
+    assert not response.isError
+    assert response.cluster_id == "j-1234567890ABCDEF0"
+    assert response.step_concurrency_level == 5
+
+
+@pytest.mark.asyncio
+async def test_modify_cluster_missing_params(handler, mock_context):
+    """Test that modifying cluster fails when required parameters are missing."""
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="modify-cluster",
+        cluster_id=None
+    )
+    
+    assert response.isError
+    assert "cluster_id is required for modify-cluster operation" in response.content[0].text
+
+
+# Modify cluster attributes tests
+@pytest.mark.asyncio
+async def test_modify_cluster_attributes_success(handler, mock_context):
+    """Test successful modification of cluster attributes."""
+    from awslabs.dataprocessing_mcp_server.models.emr_models import ModifyClusterAttributesResponse
+    
+    handler.emr_client = MagicMock()
+    handler.emr_client.set_termination_protection.return_value = {}
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="modify-cluster-attributes",
+        cluster_id="j-1234567890ABCDEF0",
+        termination_protected=True
+    )
+    
+    assert isinstance(response, ModifyClusterAttributesResponse)
+    assert not response.isError
+    assert response.cluster_id == "j-1234567890ABCDEF0"
+
+
+@pytest.mark.asyncio
+async def test_modify_cluster_attributes_missing_params(handler, mock_context):
+    """Test that modifying cluster attributes fails when no attributes are provided."""
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="modify-cluster-attributes",
+        cluster_id="j-1234567890ABCDEF0",
+        auto_terminate=None,
+        termination_protected=None
+    )
+    
+    assert response.isError
+    assert "At least one of auto_terminate or termination_protected must be provided" in response.content[0].text
+
+
+# Security configuration tests
+@pytest.mark.asyncio
+async def test_create_security_configuration_success(handler, mock_context):
+    """Test successful creation of security configuration."""
+    from awslabs.dataprocessing_mcp_server.models.emr_models import CreateSecurityConfigurationResponse
+    import datetime
+    
+    handler.emr_client = MagicMock()
+    handler.emr_client.create_security_configuration.return_value = {
+        "Name": "test-config",
+        "CreationDateTime": datetime.datetime(2023, 1, 1)
+    }
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="create-security-configuration",
+        security_configuration_name="test-config",
+        security_configuration_json={"EncryptionConfiguration": {}}
+    )
+    
+    assert isinstance(response, CreateSecurityConfigurationResponse)
+    assert not response.isError
+    assert response.name == "test-config"
+
+
+@pytest.mark.asyncio
+async def test_create_security_configuration_missing_params(handler, mock_context):
+    """Test that creating security configuration fails when parameters are missing."""
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="create-security-configuration",
+        security_configuration_name=None
+    )
+    
+    assert response.isError
+    assert "security_configuration_name and security_configuration_json are required" in response.content[0].text
+
+
+# Invalid operation test
+@pytest.mark.asyncio
+async def test_invalid_operation(handler, mock_context):
+    """Test handling of invalid operation."""
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="invalid-operation"
+    )
+    
+    assert response.isError
+    assert "Invalid operation: invalid-operation" in response.content[0].text
+
+
+# Test with optional parameters
+@pytest.mark.asyncio
+async def test_create_cluster_with_optional_params(handler, mock_context):
+    """Test creating cluster with optional parameters."""
+    handler.emr_client = MagicMock()
+    handler.emr_client.run_job_flow.return_value = {"JobFlowId": "j-1234567890ABCDEF0"}
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="create-cluster",
+        name="TestCluster",
+        release_label="emr-7.9.0",
+        instances={"InstanceGroups": []},
+        applications=[{"Name": "Spark"}, {"Name": "Hadoop"}],
+        log_uri="s3://my-bucket/logs/",
+        visible_to_all_users=False,
+        bootstrap_actions=[{"Name": "setup", "ScriptBootstrapAction": {"Path": "s3://bucket/script.sh"}}]
+    )
+    
+    assert not response.isError
+    # Verify that optional parameters were passed to the AWS call
+    call_args = handler.emr_client.run_job_flow.call_args[1]
+    assert call_args["Applications"] == [{"Name": "Spark"}, {"Name": "Hadoop"}]
+    assert call_args["LogUri"] == "s3://my-bucket/logs/"
+    assert call_args["VisibleToAllUsers"] is False
+
+# Additional test cases for better coverage
+
+# Test _create_error_response method for different operations
+@pytest.mark.asyncio
+async def test_create_error_response_coverage(handler, mock_context):
+    """Test _create_error_response for different operation types."""
+    # Test modify-cluster-attributes error response
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="modify-cluster-attributes",
+        cluster_id=None
+    )
+    assert response.isError
+    assert "cluster_id is required" in response.content[0].text
+
+# Test modify cluster with missing step_concurrency_level
+@pytest.mark.asyncio
+async def test_modify_cluster_missing_step_concurrency(handler, mock_context):
+    """Test modify cluster fails when step_concurrency_level is missing."""
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="modify-cluster",
+        cluster_id="j-1234567890ABCDEF0",
+        step_concurrency_level=None
+    )
+    
+    assert response.isError
+    assert "step_concurrency_level is required for modify-cluster operation" in response.content[0].text
+
+# Test modify cluster attributes with both parameters
+@pytest.mark.asyncio
+async def test_modify_cluster_attributes_both_params(handler, mock_context):
+    """Test modifying cluster attributes with both auto_terminate and termination_protected."""
+    handler.emr_client = MagicMock()
+    handler.emr_client.set_termination_protection.return_value = {}
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="modify-cluster-attributes",
+        cluster_id="j-1234567890ABCDEF0",
+        auto_terminate=True,
+        termination_protected=False
+    )
+    
+    assert not response.isError
+    # Should be called twice - once for auto_terminate, once for termination_protected
+    assert handler.emr_client.set_termination_protection.call_count == 2
+
+# Test terminate clusters with exception during describe
+@pytest.mark.asyncio
+async def test_terminate_clusters_describe_exception(handler, mock_context):
+    """Test terminate clusters when describe_cluster raises exception."""
+    handler.emr_client = MagicMock()
+    handler.emr_client.describe_cluster.side_effect = Exception("Cluster not found")
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="terminate-clusters",
+        cluster_ids=["j-nonexistent"]
+    )
+    
+    assert response.isError
+    assert "Cannot terminate clusters" in response.content[0].text
+
+# Test list clusters with all optional parameters
+@pytest.mark.asyncio
+async def test_list_clusters_with_all_params(handler, mock_context):
+    """Test list clusters with all optional parameters."""
+    handler.emr_client = MagicMock()
+    handler.emr_client.list_clusters.return_value = {
+        "Clusters": [],
+        "Marker": None
+    }
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="list-clusters",
+        cluster_states=["RUNNING"],
+        created_after="2023-01-01",
+        created_before="2023-12-31",
+        marker="test-marker"
+    )
+    
+    assert not response.isError
+    call_args = handler.emr_client.list_clusters.call_args[1]
+    assert call_args["ClusterStates"] == ["RUNNING"]
+    assert call_args["CreatedAfter"] == "2023-01-01"
+    assert call_args["CreatedBefore"] == "2023-12-31"
+    assert call_args["Marker"] == "test-marker"
+
+# Test delete security configuration
+@pytest.mark.asyncio
+async def test_delete_security_configuration_success(handler, mock_context):
+    """Test successful deletion of security configuration."""
+    from awslabs.dataprocessing_mcp_server.models.emr_models import DeleteSecurityConfigurationResponse
+    
+    handler.emr_client = MagicMock()
+    handler.emr_client.delete_security_configuration.return_value = {}
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="delete-security-configuration",
+        security_configuration_name="test-config"
+    )
+    
+    assert isinstance(response, DeleteSecurityConfigurationResponse)
+    assert not response.isError
+    assert response.name == "test-config"
+
+@pytest.mark.asyncio
+async def test_delete_security_configuration_missing_name(handler, mock_context):
+    """Test delete security configuration fails when name is missing."""
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="delete-security-configuration",
+        security_configuration_name=None
+    )
+    
+    assert response.isError
+    assert "security_configuration_name is required" in response.content[0].text
+
+# Test describe security configuration
+@pytest.mark.asyncio
+async def test_describe_security_configuration_success(handler, mock_context):
+    """Test successful description of security configuration."""
+    from awslabs.dataprocessing_mcp_server.models.emr_models import DescribeSecurityConfigurationResponse
+    import datetime
+    
+    handler.emr_client = MagicMock()
+    handler.emr_client.describe_security_configuration.return_value = {
+        "Name": "test-config",
+        "SecurityConfiguration": '{"EncryptionConfiguration": {}}',
+        "CreationDateTime": datetime.datetime(2023, 1, 1)
+    }
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="describe-security-configuration",
+        security_configuration_name="test-config"
+    )
+    
+    assert isinstance(response, DescribeSecurityConfigurationResponse)
+    assert not response.isError
+    assert response.name == "test-config"
+    assert response.security_configuration == '{"EncryptionConfiguration": {}}'
+
+@pytest.mark.asyncio
+async def test_describe_security_configuration_missing_name(handler, mock_context):
+    """Test describe security configuration fails when name is missing."""
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="describe-security-configuration",
+        security_configuration_name=None
+    )
+    
+    assert response.isError
+    assert "security_configuration_name is required" in response.content[0].text
+
+# Test list security configurations
+@pytest.mark.asyncio
+async def test_list_security_configurations_success(handler, mock_context):
+    """Test successful listing of security configurations."""
+    from awslabs.dataprocessing_mcp_server.models.emr_models import ListSecurityConfigurationsResponse
+    
+    handler.emr_client = MagicMock()
+    handler.emr_client.list_security_configurations.return_value = {
+        "SecurityConfigurations": [
+            {"Name": "config1", "CreationDateTime": "2023-01-01"},
+            {"Name": "config2", "CreationDateTime": "2023-01-02"}
+        ],
+        "Marker": "next-token"
+    }
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="list-security-configurations",
+        marker="test-marker"
+    )
+    
+    assert isinstance(response, ListSecurityConfigurationsResponse)
+    assert not response.isError
+    assert response.count == 2
+    assert response.marker == "next-token"
+
+# Test create cluster with all optional parameters
+@pytest.mark.asyncio
+async def test_create_cluster_all_optional_params(handler, mock_context):
+    """Test creating cluster with all optional parameters."""
+    handler.emr_client = MagicMock()
+    handler.emr_client.run_job_flow.return_value = {"JobFlowId": "j-1234567890ABCDEF0"}
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="create-cluster",
+        name="TestCluster",
+        release_label="emr-7.9.0",
+        instances={"InstanceGroups": []},
+        log_encryption_kms_key_id="arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+        steps=[{"Name": "test-step"}],
+        configurations=[{"Classification": "spark"}],
+        service_role="EMR_DefaultRole",
+        job_flow_role="EMR_EC2_DefaultRole",
+        security_configuration="test-security-config",
+        auto_scaling_role="EMR_AutoScaling_DefaultRole",
+        scale_down_behavior="TERMINATE_AT_TASK_COMPLETION",
+        custom_ami_id="ami-12345678",
+        ebs_root_volume_size=20,
+        ebs_root_volume_iops=3000,
+        ebs_root_volume_throughput=125,
+        repo_upgrade_on_boot="SECURITY",
+        kerberos_attributes={"Realm": "EC2.INTERNAL"},
+        unhealthy_node_replacement=True,
+        os_release_label="2.0.20220606.1",
+        placement_groups=[{"InstanceRole": "MASTER", "PlacementStrategy": "SPREAD"}]
+    )
+    
+    assert not response.isError
+    call_args = handler.emr_client.run_job_flow.call_args[1]
+    assert call_args["LogEncryptionKmsKeyId"] == "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+    assert call_args["Steps"] == [{"Name": "test-step"}]
+    assert call_args["Configurations"] == [{"Classification": "spark"}]
+    assert call_args["ServiceRole"] == "EMR_DefaultRole"
+    assert call_args["JobFlowRole"] == "EMR_EC2_DefaultRole"
+    assert call_args["SecurityConfiguration"] == "test-security-config"
+    assert call_args["AutoScalingRole"] == "EMR_AutoScaling_DefaultRole"
+    assert call_args["ScaleDownBehavior"] == "TERMINATE_AT_TASK_COMPLETION"
+    assert call_args["CustomAmiId"] == "ami-12345678"
+    assert call_args["EbsRootVolumeSize"] == 20
+    assert call_args["EbsRootVolumeIops"] == 3000
+    assert call_args["EbsRootVolumeThroughput"] == 125
+    assert call_args["RepoUpgradeOnBoot"] == "SECURITY"
+    assert call_args["KerberosAttributes"] == {"Realm": "EC2.INTERNAL"}
+    assert call_args["UnhealthyNodeReplacement"] is True
+    assert call_args["OSReleaseLabel"] == "2.0.20220606.1"
+    assert call_args["PlacementGroups"] == [{"InstanceRole": "MASTER", "PlacementStrategy": "SPREAD"}]
+
+# Test create security configuration with string CreationDateTime
+@pytest.mark.asyncio
+async def test_create_security_configuration_string_datetime(handler, mock_context):
+    """Test create security configuration with string CreationDateTime."""
+    handler.emr_client = MagicMock()
+    handler.emr_client.create_security_configuration.return_value = {
+        "Name": "test-config",
+        "CreationDateTime": "2023-01-01T00:00:00Z"  # String instead of datetime object
+    }
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="create-security-configuration",
+        security_configuration_name="test-config",
+        security_configuration_json={"EncryptionConfiguration": {}}
+    )
+    
+    assert not response.isError
+    assert response.creation_date_time == "2023-01-01T00:00:00Z"
+
+# Test describe security configuration with string CreationDateTime
+@pytest.mark.asyncio
+async def test_describe_security_configuration_string_datetime(handler, mock_context):
+    """Test describe security configuration with string CreationDateTime."""
+    handler.emr_client = MagicMock()
+    handler.emr_client.describe_security_configuration.return_value = {
+        "Name": "test-config",
+        "SecurityConfiguration": "{}",
+        "CreationDateTime": "2023-01-01T00:00:00Z"  # String instead of datetime object
+    }
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="describe-security-configuration",
+        security_configuration_name="test-config"
+    )
+    
+    assert not response.isError
+    assert response.creation_date_time == "2023-01-01T00:00:00Z"
+
+# Test write access restrictions for all write operations
+@pytest.mark.asyncio
+async def test_modify_cluster_no_write_access(mock_aws_helper, mock_context):
+    """Test that modifying cluster fails without write access."""
+    mcp = MagicMock()
+    mcp.tool = MagicMock(return_value=lambda f: f)
+    handler = EMREc2ClusterHandler(mcp, allow_write=False)
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="modify-cluster",
+        cluster_id="j-1234567890ABCDEF0",
+        step_concurrency_level=5
+    )
+    
+    assert response.isError
+    assert "Operation modify-cluster is not allowed without write access" in response.content[0].text
+
+@pytest.mark.asyncio
+async def test_modify_cluster_attributes_no_write_access(mock_aws_helper, mock_context):
+    """Test that modifying cluster attributes fails without write access."""
+    mcp = MagicMock()
+    mcp.tool = MagicMock(return_value=lambda f: f)
+    handler = EMREc2ClusterHandler(mcp, allow_write=False)
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="modify-cluster-attributes",
+        cluster_id="j-1234567890ABCDEF0",
+        termination_protected=True
+    )
+    
+    assert response.isError
+    assert "Operation modify-cluster-attributes is not allowed without write access" in response.content[0].text
+
+@pytest.mark.asyncio
+async def test_create_security_configuration_no_write_access(mock_aws_helper, mock_context):
+    """Test that creating security configuration fails without write access."""
+    mcp = MagicMock()
+    mcp.tool = MagicMock(return_value=lambda f: f)
+    handler = EMREc2ClusterHandler(mcp, allow_write=False)
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="create-security-configuration",
+        security_configuration_name="test-config",
+        security_configuration_json={}
+    )
+    
+    assert response.isError
+    assert "Operation create-security-configuration is not allowed without write access" in response.content[0].text
+
+@pytest.mark.asyncio
+async def test_delete_security_configuration_no_write_access(mock_aws_helper, mock_context):
+    """Test that deleting security configuration fails without write access."""
+    mcp = MagicMock()
+    mcp.tool = MagicMock(return_value=lambda f: f)
+    handler = EMREc2ClusterHandler(mcp, allow_write=False)
+    
+    response = await handler.manage_aws_emr_clusters(
+        mock_context,
+        operation="delete-security-configuration",
+        security_configuration_name="test-config"
+    )
+    
+    assert response.isError
+    assert "Operation delete-security-configuration is not allowed without write access" in response.content[0].text

--- a/src/dataprocessing-mcp-server/tests/models/test_emr_models.py
+++ b/src/dataprocessing-mcp-server/tests/models/test_emr_models.py
@@ -1,34 +1,621 @@
-"""Tests for EMR models.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-These tests validate the EMR model functionality with minimal dependencies.
-"""
+"""Tests for EMR models."""
 
-import unittest
+import pytest
+from awslabs.dataprocessing_mcp_server.models.emr_models import (
+    AddInstanceFleetResponse,
+    AddInstanceFleetResponseModel,
+    AddInstanceGroupsResponse,
+    AddInstanceGroupsResponseModel,
+    AddStepsResponse,
+    AddStepsResponseModel,
+    CancelStepsResponse,
+    CancelStepsResponseModel,
+    DescribeStepResponse,
+    DescribeStepResponseModel,
+    ListInstanceFleetsResponse,
+    ListInstanceFleetsResponseModel,
+    ListInstancesResponse,
+    ListInstancesResponseModel,
+    ListStepsResponse,
+    ListStepsResponseModel,
+    ListSupportedInstanceTypesResponse,
+    ListSupportedInstanceTypesResponseModel,
+    ModifyInstanceFleetResponse,
+    ModifyInstanceFleetResponseModel,
+    ModifyInstanceGroupsResponse,
+    ModifyInstanceGroupsResponseModel,
+)
 
 
-class TestEMRModels(unittest.TestCase):
-    """Test the EMR models."""
+@pytest.mark.asyncio
+async def test_add_instance_fleet_response_model():
+    """Test AddInstanceFleetResponseModel."""
+    model = AddInstanceFleetResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        instance_fleet_id='if-1234567890ABCDEF0',
+        cluster_arn='arn:aws:elasticmapreduce:us-west-2:123456789012:cluster/j-1234567890ABCDEF0',
+        operation='add_fleet',
+    )
+    assert model.cluster_id == 'j-1234567890ABCDEF0'
+    assert model.instance_fleet_id == 'if-1234567890ABCDEF0'
+    assert (
+        model.cluster_arn
+        == 'arn:aws:elasticmapreduce:us-west-2:123456789012:cluster/j-1234567890ABCDEF0'
+    )
+    assert model.operation == 'add_fleet'
 
-    def test_emr_models_placeholder(self):
-        """Simple test to verify test infrastructure works."""
-        self.assertTrue(True, 'EMR models test passes')
 
-    def test_response_model_structure(self):
-        """Test the structure of EMR response models."""
-        # Define the expected structure
-        write_operations = [
-            'add-instance-fleet',
-            'add-instance-groups',
-            'modify-instance-fleet',
-            'modify-instance-groups',
-        ]
+@pytest.mark.asyncio
+async def test_add_instance_fleet_response():
+    """Test AddInstanceFleetResponse."""
+    model = AddInstanceFleetResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        instance_fleet_id='if-1234567890ABCDEF0',
+        cluster_arn='arn:aws:elasticmapreduce:us-west-2:123456789012:cluster/j-1234567890ABCDEF0',
+        operation='add_fleet',
+    )
+    response = AddInstanceFleetResponse.create(
+        is_error=False,
+        content=[{'type': 'text', 'text': 'Successfully added instance fleet'}],
+        model=model,
+    )
+    assert isinstance(response, AddInstanceFleetResponse)
+    assert not response.isError
+    assert response.cluster_id == 'j-1234567890ABCDEF0'
+    assert response.instance_fleet_id == 'if-1234567890ABCDEF0'
+    assert (
+        response.cluster_arn
+        == 'arn:aws:elasticmapreduce:us-west-2:123456789012:cluster/j-1234567890ABCDEF0'
+    )
+    assert response.operation == 'add_fleet'
 
-        read_operations = [
-            'list-instance-fleets',
-            'list-instances',
-            'list-supported-instance-types',
-        ]
 
-        # Just verify the lists are correct
-        self.assertEqual(len(write_operations), 4)
-        self.assertEqual(len(read_operations), 3)
+@pytest.mark.asyncio
+async def test_add_instance_groups_response_model():
+    """Test AddInstanceGroupsResponseModel."""
+    model = AddInstanceGroupsResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        job_flow_id='j-1234567890ABCDEF0',
+        instance_group_ids=['ig-1234567890ABCDEF0', 'ig-0987654321ABCDEF0'],
+        cluster_arn='arn:aws:elasticmapreduce:us-west-2:123456789012:cluster/j-1234567890ABCDEF0',
+        operation='add_groups',
+    )
+    assert model.cluster_id == 'j-1234567890ABCDEF0'
+    assert model.job_flow_id == 'j-1234567890ABCDEF0'
+    assert model.instance_group_ids == ['ig-1234567890ABCDEF0', 'ig-0987654321ABCDEF0']
+    assert (
+        model.cluster_arn
+        == 'arn:aws:elasticmapreduce:us-west-2:123456789012:cluster/j-1234567890ABCDEF0'
+    )
+    assert model.operation == 'add_groups'
+
+
+@pytest.mark.asyncio
+async def test_add_instance_groups_response():
+    """Test AddInstanceGroupsResponse."""
+    model = AddInstanceGroupsResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        job_flow_id='j-1234567890ABCDEF0',
+        instance_group_ids=['ig-1234567890ABCDEF0', 'ig-0987654321ABCDEF0'],
+        cluster_arn='arn:aws:elasticmapreduce:us-west-2:123456789012:cluster/j-1234567890ABCDEF0',
+        operation='add_groups',
+    )
+    response = AddInstanceGroupsResponse.create(
+        is_error=False,
+        content=[{'type': 'text', 'text': 'Successfully added instance groups'}],
+        model=model,
+    )
+    assert isinstance(response, AddInstanceGroupsResponse)
+    assert not response.isError
+    assert response.cluster_id == 'j-1234567890ABCDEF0'
+    assert response.job_flow_id == 'j-1234567890ABCDEF0'
+    assert response.instance_group_ids == ['ig-1234567890ABCDEF0', 'ig-0987654321ABCDEF0']
+    assert (
+        response.cluster_arn
+        == 'arn:aws:elasticmapreduce:us-west-2:123456789012:cluster/j-1234567890ABCDEF0'
+    )
+    assert response.operation == 'add_groups'
+
+
+@pytest.mark.asyncio
+async def test_modify_instance_fleet_response_model():
+    """Test ModifyInstanceFleetResponseModel."""
+    model = ModifyInstanceFleetResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        instance_fleet_id='if-1234567890ABCDEF0',
+        operation='modify_fleet',
+    )
+    assert model.cluster_id == 'j-1234567890ABCDEF0'
+    assert model.instance_fleet_id == 'if-1234567890ABCDEF0'
+    assert model.operation == 'modify_fleet'
+
+
+@pytest.mark.asyncio
+async def test_modify_instance_fleet_response():
+    """Test ModifyInstanceFleetResponse."""
+    model = ModifyInstanceFleetResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        instance_fleet_id='if-1234567890ABCDEF0',
+        operation='modify_fleet',
+    )
+    response = ModifyInstanceFleetResponse.create(
+        is_error=False,
+        content=[{'type': 'text', 'text': 'Successfully modified instance fleet'}],
+        model=model,
+    )
+    assert isinstance(response, ModifyInstanceFleetResponse)
+    assert not response.isError
+    assert response.cluster_id == 'j-1234567890ABCDEF0'
+    assert response.instance_fleet_id == 'if-1234567890ABCDEF0'
+    assert response.operation == 'modify_fleet'
+
+
+@pytest.mark.asyncio
+async def test_modify_instance_groups_response_model():
+    """Test ModifyInstanceGroupsResponseModel."""
+    model = ModifyInstanceGroupsResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        instance_group_ids=['ig-1234567890ABCDEF0', 'ig-0987654321ABCDEF0'],
+        operation='modify_groups',
+    )
+    assert model.cluster_id == 'j-1234567890ABCDEF0'
+    assert model.instance_group_ids == ['ig-1234567890ABCDEF0', 'ig-0987654321ABCDEF0']
+    assert model.operation == 'modify_groups'
+
+
+@pytest.mark.asyncio
+async def test_modify_instance_groups_response():
+    """Test ModifyInstanceGroupsResponse."""
+    model = ModifyInstanceGroupsResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        instance_group_ids=['ig-1234567890ABCDEF0', 'ig-0987654321ABCDEF0'],
+        operation='modify_groups',
+    )
+    response = ModifyInstanceGroupsResponse.create(
+        is_error=False,
+        content=[{'type': 'text', 'text': 'Successfully modified instance groups'}],
+        model=model,
+    )
+    assert isinstance(response, ModifyInstanceGroupsResponse)
+    assert not response.isError
+    assert response.cluster_id == 'j-1234567890ABCDEF0'
+    assert response.instance_group_ids == ['ig-1234567890ABCDEF0', 'ig-0987654321ABCDEF0']
+    assert response.operation == 'modify_groups'
+
+
+@pytest.mark.asyncio
+async def test_list_instance_fleets_response_model():
+    """Test ListInstanceFleetsResponseModel."""
+    model = ListInstanceFleetsResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        instance_fleets=[
+            {'Id': 'if-1234567890ABCDEF0', 'Name': 'InstanceFleet1'},
+            {'Id': 'if-0987654321ABCDEF0', 'Name': 'InstanceFleet2'},
+        ],
+        count=2,
+        marker='pagination-token',
+        operation='list',
+    )
+    assert model.cluster_id == 'j-1234567890ABCDEF0'
+    assert model.instance_fleets == [
+        {'Id': 'if-1234567890ABCDEF0', 'Name': 'InstanceFleet1'},
+        {'Id': 'if-0987654321ABCDEF0', 'Name': 'InstanceFleet2'},
+    ]
+    assert model.count == 2
+    assert model.marker == 'pagination-token'
+    assert model.operation == 'list'
+
+
+@pytest.mark.asyncio
+async def test_list_instance_fleets_response():
+    """Test ListInstanceFleetsResponse."""
+    model = ListInstanceFleetsResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        instance_fleets=[
+            {'Id': 'if-1234567890ABCDEF0', 'Name': 'InstanceFleet1'},
+            {'Id': 'if-0987654321ABCDEF0', 'Name': 'InstanceFleet2'},
+        ],
+        count=2,
+        marker='pagination-token',
+        operation='list',
+    )
+    response = ListInstanceFleetsResponse.create(
+        is_error=False,
+        content=[{'type': 'text', 'text': 'Successfully listed instance fleets'}],
+        model=model,
+    )
+    assert isinstance(response, ListInstanceFleetsResponse)
+    assert not response.isError
+    assert response.cluster_id == 'j-1234567890ABCDEF0'
+    assert response.instance_fleets == [
+        {'Id': 'if-1234567890ABCDEF0', 'Name': 'InstanceFleet1'},
+        {'Id': 'if-0987654321ABCDEF0', 'Name': 'InstanceFleet2'},
+    ]
+    assert response.count == 2
+    assert response.marker == 'pagination-token'
+    assert response.operation == 'list'
+
+
+@pytest.mark.asyncio
+async def test_list_instances_response_model():
+    """Test ListInstancesResponseModel."""
+    model = ListInstancesResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        instances=[
+            {'Id': 'i-1234567890ABCDEF0', 'InstanceGroupName': 'InstanceGroup1'},
+            {'Id': 'i-0987654321ABCDEF0', 'InstanceGroupName': 'InstanceGroup2'},
+        ],
+        count=2,
+        marker='pagination-token',
+        operation='list',
+    )
+    assert model.cluster_id == 'j-1234567890ABCDEF0'
+    assert model.instances == [
+        {'Id': 'i-1234567890ABCDEF0', 'InstanceGroupName': 'InstanceGroup1'},
+        {'Id': 'i-0987654321ABCDEF0', 'InstanceGroupName': 'InstanceGroup2'},
+    ]
+    assert model.count == 2
+    assert model.marker == 'pagination-token'
+    assert model.operation == 'list'
+
+
+@pytest.mark.asyncio
+async def test_list_instances_response():
+    """Test ListInstancesResponse."""
+    model = ListInstancesResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        instances=[
+            {'Id': 'i-1234567890ABCDEF0', 'InstanceGroupName': 'InstanceGroup1'},
+            {'Id': 'i-0987654321ABCDEF0', 'InstanceGroupName': 'InstanceGroup2'},
+        ],
+        count=2,
+        marker='pagination-token',
+        operation='list',
+    )
+    response = ListInstancesResponse.create(
+        is_error=False,
+        content=[{'type': 'text', 'text': 'Successfully listed instances'}],
+        model=model,
+    )
+    assert isinstance(response, ListInstancesResponse)
+    assert not response.isError
+    assert response.cluster_id == 'j-1234567890ABCDEF0'
+    assert response.instances == [
+        {'Id': 'i-1234567890ABCDEF0', 'InstanceGroupName': 'InstanceGroup1'},
+        {'Id': 'i-0987654321ABCDEF0', 'InstanceGroupName': 'InstanceGroup2'},
+    ]
+    assert response.count == 2
+    assert response.marker == 'pagination-token'
+    assert response.operation == 'list'
+
+
+@pytest.mark.asyncio
+async def test_list_supported_instance_types_response_model():
+    """Test ListSupportedInstanceTypesResponseModel."""
+    model = ListSupportedInstanceTypesResponseModel(
+        instance_types=[
+            {'InstanceType': 'm5.xlarge', 'ReleaseLabel': 'emr-7.9.0'},
+            {'InstanceType': 'm5.2xlarge', 'ReleaseLabel': 'emr-7.9.0'},
+        ],
+        count=2,
+        marker='pagination-token',
+        release_label='emr-7.9.0',
+        operation='list',
+    )
+    assert model.instance_types == [
+        {'InstanceType': 'm5.xlarge', 'ReleaseLabel': 'emr-7.9.0'},
+        {'InstanceType': 'm5.2xlarge', 'ReleaseLabel': 'emr-7.9.0'},
+    ]
+    assert model.count == 2
+    assert model.marker == 'pagination-token'
+    assert model.release_label == 'emr-7.9.0'
+    assert model.operation == 'list'
+
+
+@pytest.mark.asyncio
+async def test_list_supported_instance_types_response():
+    """Test ListSupportedInstanceTypesResponse."""
+    model = ListSupportedInstanceTypesResponseModel(
+        instance_types=[
+            {'InstanceType': 'm5.xlarge', 'ReleaseLabel': 'emr-7.9.0'},
+            {'InstanceType': 'm5.2xlarge', 'ReleaseLabel': 'emr-7.9.0'},
+        ],
+        count=2,
+        marker='pagination-token',
+        release_label='emr-7.9.0',
+        operation='list',
+    )
+    response = ListSupportedInstanceTypesResponse.create(
+        is_error=False,
+        content=[{'type': 'text', 'text': 'Successfully listed supported instance types'}],
+        model=model,
+    )
+    assert isinstance(response, ListSupportedInstanceTypesResponse)
+    assert not response.isError
+    assert response.instance_types == [
+        {'InstanceType': 'm5.xlarge', 'ReleaseLabel': 'emr-7.9.0'},
+        {'InstanceType': 'm5.2xlarge', 'ReleaseLabel': 'emr-7.9.0'},
+    ]
+    assert response.count == 2
+    assert response.marker == 'pagination-token'
+    assert response.release_label == 'emr-7.9.0'
+    assert response.operation == 'list'
+
+
+@pytest.mark.asyncio
+async def test_add_steps_response_model():
+    """Test AddStepsResponseModel."""
+    model = AddStepsResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        step_ids=['s-1234567890ABCDEF0', 's-0987654321ABCDEF0'],
+        count=2,
+        operation='add',
+    )
+    assert model.cluster_id == 'j-1234567890ABCDEF0'
+    assert model.step_ids == ['s-1234567890ABCDEF0', 's-0987654321ABCDEF0']
+    assert model.count == 2
+    assert model.operation == 'add'
+
+
+@pytest.mark.asyncio
+async def test_add_steps_response():
+    """Test AddStepsResponse."""
+    model = AddStepsResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        step_ids=['s-1234567890ABCDEF0', 's-0987654321ABCDEF0'],
+        count=2,
+        operation='add',
+    )
+    response = AddStepsResponse.create(
+        is_error=False, content=[{'type': 'text', 'text': 'Successfully added steps'}], model=model
+    )
+    assert isinstance(response, AddStepsResponse)
+    assert not response.isError
+    assert response.cluster_id == 'j-1234567890ABCDEF0'
+    assert response.step_ids == ['s-1234567890ABCDEF0', 's-0987654321ABCDEF0']
+    assert response.count == 2
+    assert response.operation == 'add'
+
+
+@pytest.mark.asyncio
+async def test_cancel_steps_response_model():
+    """Test CancelStepsResponseModel."""
+    model = CancelStepsResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        step_cancellation_info=[
+            {
+                'StepId': 's-1234567890ABCDEF0',
+                'Status': 'SUBMITTED',
+                'Reason': 'Test cancellation',
+            },
+            {'StepId': 's-0987654321ABCDEF0', 'Status': 'FAILED', 'Reason': 'Test cancellation'},
+        ],
+        count=2,
+        operation='cancel',
+    )
+    assert model.cluster_id == 'j-1234567890ABCDEF0'
+    assert model.step_cancellation_info == [
+        {'StepId': 's-1234567890ABCDEF0', 'Status': 'SUBMITTED', 'Reason': 'Test cancellation'},
+        {'StepId': 's-0987654321ABCDEF0', 'Status': 'FAILED', 'Reason': 'Test cancellation'},
+    ]
+    assert model.count == 2
+    assert model.operation == 'cancel'
+
+
+@pytest.mark.asyncio
+async def test_cancel_steps_response():
+    """Test CancelStepsResponse."""
+    model = CancelStepsResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        step_cancellation_info=[
+            {
+                'StepId': 's-1234567890ABCDEF0',
+                'Status': 'SUBMITTED',
+                'Reason': 'Test cancellation',
+            },
+            {'StepId': 's-0987654321ABCDEF0', 'Status': 'FAILED', 'Reason': 'Test cancellation'},
+        ],
+        count=2,
+        operation='cancel',
+    )
+    response = CancelStepsResponse.create(
+        is_error=False,
+        content=[{'type': 'text', 'text': 'Successfully cancelled steps'}],
+        model=model,
+    )
+
+    assert isinstance(response, CancelStepsResponse)
+    assert not response.isError
+    assert response.cluster_id == 'j-1234567890ABCDEF0'
+    assert response.step_cancellation_info == [
+        {'StepId': 's-1234567890ABCDEF0', 'Status': 'SUBMITTED', 'Reason': 'Test cancellation'},
+        {'StepId': 's-0987654321ABCDEF0', 'Status': 'FAILED', 'Reason': 'Test cancellation'},
+    ]
+    assert response.count == 2
+    assert response.operation == 'cancel'
+
+
+@pytest.mark.asyncio
+async def test_describe_step_response_model():
+    """Test DescribeStepResponseModel."""
+    model = DescribeStepResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        step={
+            'Id': 's-1234567890ABCDEF0',
+            'Name': 'Test Step',
+            'Status': {'State': 'COMPLETED'},
+            'Config': {'Jar': 'command-runner.jar'},
+        },
+        operation='describe',
+    )
+    assert model.cluster_id == 'j-1234567890ABCDEF0'
+    assert model.step['Id'] == 's-1234567890ABCDEF0'
+    assert model.step['Name'] == 'Test Step'
+    assert model.operation == 'describe'
+
+
+@pytest.mark.asyncio
+async def test_describe_step_response():
+    """Test DescribeStepResponse."""
+    model = DescribeStepResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        step={
+            'Id': 's-1234567890ABCDEF0',
+            'Name': 'Test Step',
+            'Status': {'State': 'COMPLETED'},
+            'Config': {'Jar': 'command-runner.jar'},
+        },
+        operation='describe',
+    )
+    response = DescribeStepResponse.create(
+        is_error=False,
+        content=[{'type': 'text', 'text': 'Successfully described step'}],
+        model=model,
+    )
+    assert isinstance(response, DescribeStepResponse)
+    assert not response.isError
+    assert response.cluster_id == 'j-1234567890ABCDEF0'
+    assert response.step['Id'] == 's-1234567890ABCDEF0'
+    assert response.operation == 'describe'
+
+
+@pytest.mark.asyncio
+async def test_list_steps_response_model():
+    """Test ListStepsResponseModel."""
+    model = ListStepsResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        steps=[
+            {'Id': 's-1234567890ABCDEF0', 'Name': 'Step1', 'Status': {'State': 'COMPLETED'}},
+            {'Id': 's-0987654321ABCDEF0', 'Name': 'Step2', 'Status': {'State': 'RUNNING'}},
+        ],
+        count=2,
+        marker='pagination-token',
+        operation='list',
+    )
+    assert model.cluster_id == 'j-1234567890ABCDEF0'
+    assert model.steps == [
+        {'Id': 's-1234567890ABCDEF0', 'Name': 'Step1', 'Status': {'State': 'COMPLETED'}},
+        {'Id': 's-0987654321ABCDEF0', 'Name': 'Step2', 'Status': {'State': 'RUNNING'}},
+    ]
+    assert model.count == 2
+    assert model.marker == 'pagination-token'
+    assert model.operation == 'list'
+
+
+@pytest.mark.asyncio
+async def test_list_steps_response():
+    """Test ListStepsResponse."""
+    model = ListStepsResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        steps=[
+            {'Id': 's-1234567890ABCDEF0', 'Name': 'Step1', 'Status': {'State': 'COMPLETED'}},
+            {'Id': 's-0987654321ABCDEF0', 'Name': 'Step2', 'Status': {'State': 'RUNNING'}},
+        ],
+        count=2,
+        marker='pagination-token',
+        operation='list',
+    )
+    response = ListStepsResponse.create(
+        is_error=False,
+        content=[{'type': 'text', 'text': 'Successfully listed steps'}],
+        model=model,
+    )
+    assert isinstance(response, ListStepsResponse)
+    assert not response.isError
+    assert response.cluster_id == 'j-1234567890ABCDEF0'
+    assert response.steps == [
+        {'Id': 's-1234567890ABCDEF0', 'Name': 'Step1', 'Status': {'State': 'COMPLETED'}},
+        {'Id': 's-0987654321ABCDEF0', 'Name': 'Step2', 'Status': {'State': 'RUNNING'}},
+    ]
+    assert response.count == 2
+    assert response.marker == 'pagination-token'
+    assert response.operation == 'list'
+
+
+# Test error responses
+@pytest.mark.asyncio
+async def test_error_response_models():
+    """Test all response models with error states."""
+    # Test AddInstanceFleetResponse with error
+    model = AddInstanceFleetResponseModel(
+        cluster_id='j-1234567890ABCDEF0',
+        instance_fleet_id='',
+        cluster_arn='',
+        operation='add_fleet',
+    )
+    response = AddInstanceFleetResponse.create(
+        is_error=True,
+        content=[{'type': 'text', 'text': 'Error adding instance fleet'}],
+        model=model,
+    )
+    assert response.isError is True
+    assert response.instance_fleet_id == ''
+
+    # Test AddStepsResponse with error
+    steps_model = AddStepsResponseModel(
+        cluster_id='j-1234567890ABCDEF0', step_ids=[], count=0, operation='add'
+    )
+    steps_response = AddStepsResponse.create(
+        is_error=True, content=[{'type': 'text', 'text': 'Error adding steps'}], model=steps_model
+    )
+    assert steps_response.isError is True
+    assert steps_response.count == 0
+
+
+# Test edge cases
+@pytest.mark.asyncio
+async def test_model_edge_cases():
+    """Test models with edge case values."""
+    # Test with None values where allowed
+    model = ListInstanceFleetsResponseModel(
+        cluster_id='j-1234567890ABCDEF0', instance_fleets=[], count=0, marker=None
+    )
+    assert model.marker is None
+    assert model.count == 0
+    assert model.instance_fleets == []
+
+    # Test with empty step cancellation info
+    cancel_model = CancelStepsResponseModel(
+        cluster_id='j-1234567890ABCDEF0', step_cancellation_info=[], count=0, operation='cancel'
+    )
+    assert cancel_model.step_cancellation_info == []
+    assert cancel_model.count == 0
+
+
+# Test default values
+@pytest.mark.asyncio
+async def test_model_defaults():
+    """Test model default values."""
+    """Test model default values."""
+    # Test AddInstanceFleetResponseModel defaults
+    model = AddInstanceFleetResponseModel(
+        cluster_id='j-1234567890ABCDEF0', instance_fleet_id='if-1234567890ABCDEF0'
+    )
+    assert model.operation == 'add_fleet'
+    assert model.cluster_arn is None
+
+    # Test AddStepsResponseModel defaults
+    steps_model = AddStepsResponseModel(
+        cluster_id='j-1234567890ABCDEF0', step_ids=['s-1234567890ABCDEF0'], count=1
+    )
+    assert steps_model.operation == 'add'
+
+    # Test DescribeStepResponseModel defaults
+    describe_model = DescribeStepResponseModel(
+        cluster_id='j-1234567890ABCDEF0', step={'Id': 's-1234567890ABCDEF0'}
+    )
+    assert describe_model.operation == 'describe'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

Added comprehensive EMR EC2 cluster management capabilities to the Data Processing MCP Server, including:

- New EMR EC2 Cluster Handler: Complete implementation for managing Amazon EMR clusters with operations for create, describe, modify, terminate, and list clusters
- Security Configuration Management: Support for creating, deleting, describing, and listing EMR security configurations
- Response Models: Type-safe Pydantic models for all EMR cluster operations with proper error handling
- Comprehensive Test Coverage: Full test suite covering all handler operations, response models, and edge cases
- Server Integration: Registered the new handler with the MCP server for immediate availability

### User experience

Before: Users had no way to manage EMR clusters through the MCP server, limiting data processing capabilities to Glue jobs and basic EMR instance/step operations.

After: Users can now perform complete EMR cluster lifecycle management through simple MCP tool calls

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
