### PR TITLE
chore(dataprocessing-mcp-server): Add Glue Commons and ETL Handlers to Readme

### DIFF
--- a/src/dataprocessing-mcp-server/README.md
+++ b/src/dataprocessing-mcp-server/README.md
@@ -10,6 +10,8 @@ Integrating the DataProcessing MCP server into AI code assistants transforms dat
 ### AWS Glue Integration
 
 * Data Catalog Management: Enables users to explore, create, and manage databases, tables, and partitions through natural language requests, automatically translating them into appropriate AWS Glue Data Catalog operations.
+* Commons: Enables users to create and manage usage profiles and security configurations, which provide users with the ability to manage the resource types and encryption of their ETL jobs and sessions.
+* ETL Job Orchestration: Provides the ability to create, monitor, and manage Glue ETL jobs with automatic script generation, job scheduling, and workflow coordination based on user-defined data transformation requirements.
 * Interactive Sessions: Provides interactive development environment for Spark and Ray workloads, enabling data exploration, debugging, and iterative development through managed Jupyter-like sessions.
 * Workflows and Triggers: Orchestrates complex ETL activities through visual workflows and automated triggers, supporting scheduled, conditional, and event-based execution patterns.
 * Crawler Management: Enables intelligent data discovery through automated crawler configuration, scheduling, and metadata extraction from various data sources.
@@ -229,6 +231,18 @@ Specifies the AWS region where Glue,EMR clusters or Athena are managed, which wi
 | manage_aws_athena_query_executions | Execute and manage AWS Athena SQL queries | batch-get-query-execution, get-query-execution, get-query-results, get-query-runtime-statistics, list-query-executions, start-query-execution, stop-query-execution | --allow-write flag for start/stop operations, appropriate AWS permissions |
 | manage_aws_athena_named_queries | Manage saved SQL queries in AWS Athena | batch-get-named-query, create-named-query, delete-named-query, get-named-query, list-named-queries, update-named-query | --allow-write flag for create/delete/update operations, appropriate AWS permissions |
 
+### Glue Commons Handler Tools
+
+| Tool Name | Description | Key Operations | Requirements |
+|-----------|-------------|----------------|--------------|
+| manage_aws_glue_usage_profiles | Manage AWS Glue Usage Profiles for resource allocation and cost management | create-profile, delete-profile, get-profile, update-profile | --allow-write flag for create/delete/update operations, appropriate AWS permissions |
+| manage_aws_glue_security_configurations | Manage AWS Glue Security Configurations for data encryption | create-security-configuration, delete-security-configuration, get-security-configuration | --allow-write flag for create/delete operations, appropriate AWS permissions |
+
+### Glue ETL Handler Tools
+
+| Tool Name | Description | Key Operations | Requirements |
+|-----------|-------------|----------------|--------------|
+| manage_aws_glue_jobs | Manage AWS Glue ETL jobs and job runs | create-job, delete-job, get-job, get-jobs, update-job, start-job-run, stop-job-run, get-job-run, get-job-runs, batch-stop-job-run, get-job-bookmark, reset-job-bookmark | --allow-write flag for create/delete/update/start/stop operations, appropriate AWS permissions |
 
 ### Glue Interactive Sessions Handler Tools
 


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

Add Glue Commons and Glue ETL Handlers to README for the dataprocessing-mcp-server

### User experience

> Please share what the user experience looks like before and after this change

Users will now be able to view details about the Glue Commons and Glue ETL Handlers from the README and understand the available tools and required arguments for each

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

Is this a breaking change? (Y/N): N

**RFC issue number**: https://github.com/awslabs/mcp/issues/614

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
