### PR TITLE
fix(dataprocessing-mcp-server): remove from __future__ import annotat…

### DIFF
--- a/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/handlers/glue/data_catalog_handler.py
+++ b/src/dataprocessing-mcp-server/awslabs/dataprocessing_mcp_server/handlers/glue/data_catalog_handler.py
@@ -14,8 +14,6 @@
 
 """DataCatalogHandler for Data Processing MCP Server."""
 
-from __future__ import annotations
-
 from awslabs.dataprocessing_mcp_server.core.glue_data_catalog.data_catalog_database_manager import (
     DataCatalogDatabaseManager,
 )


### PR DESCRIPTION
…ions

<!-- markdownlint-disable MD041 MD043 -->
Fixes

## Summary

### Changes

> Fix the issue not able to connect to AWS Glue Data Catalog handler
> Remove unneeded imports

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
